### PR TITLE
Rocky support (#17)

### DIFF
--- a/rocky/admin-openrc.sh
+++ b/rocky/admin-openrc.sh
@@ -1,0 +1,8 @@
+export OS_PROJECT_DOMAIN_NAME=default
+export OS_USER_DOMAIN_NAME=default
+export OS_PROJECT_NAME=admin
+export OS_USERNAME=admin
+export OS_PASSWORD=avi123
+export OS_AUTH_URL=http://localhost:5000/v3
+export OS_IDENTITY_API_VERSION=3
+export OS_IMAGE_API_VERSION=2

--- a/rocky/barbican-api-paste.ini
+++ b/rocky/barbican-api-paste.ini
@@ -1,0 +1,63 @@
+[composite:main]
+use = egg:Paste#urlmap
+/: barbican_version
+/v1: barbican-api-keystone
+
+# Use this pipeline for Barbican API - versions no authentication
+[pipeline:barbican_version]
+pipeline = cors http_proxy_to_wsgi versionapp
+
+# Use this pipeline for Barbican API - DEFAULT no authentication
+[pipeline:barbican_api]
+pipeline = cors authtoken context apiapp
+
+#Use this pipeline to activate a repoze.profile middleware and HTTP port,
+#  to provide profiling information for the REST API processing.
+[pipeline:barbican-profile]
+pipeline = cors http_proxy_to_wsgi unauthenticated-context egg:Paste#cgitb egg:Paste#httpexceptions profile apiapp
+
+#Use this pipeline for keystone auth
+[pipeline:barbican-api-keystone]
+pipeline = cors http_proxy_to_wsgi authtoken context apiapp
+
+#Use this pipeline for keystone auth with audit feature
+[pipeline:barbican-api-keystone-audit]
+pipeline = http_proxy_to_wsgi authtoken context audit apiapp
+
+[app:apiapp]
+paste.app_factory = barbican.api.app:create_main_app
+
+[app:versionapp]
+paste.app_factory = barbican.api.app:create_version_app
+
+[filter:simple]
+paste.filter_factory = barbican.api.middleware.simple:SimpleFilter.factory
+
+[filter:unauthenticated-context]
+paste.filter_factory = barbican.api.middleware.context:UnauthenticatedContextMiddleware.factory
+
+[filter:context]
+paste.filter_factory = barbican.api.middleware.context:ContextMiddleware.factory
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/barbican/api_audit_map.conf
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+
+[filter:profile]
+use = egg:repoze.profile
+log_filename = myapp.profile
+cachegrind_filename = cachegrind.out.myapp
+discard_first_request = true
+path = /__profile__
+flush_at_shutdown = true
+unwind = false
+
+[filter:cors]
+paste.filter_factory = oslo_middleware.cors:filter_factory
+oslo_config_project = barbican
+
+[filter:http_proxy_to_wsgi]
+paste.filter_factory = oslo_middleware:HTTPProxyToWSGI.factory

--- a/rocky/barbican.conf
+++ b/rocky/barbican.conf
@@ -1,0 +1,570 @@
+[DEFAULT]
+# Show debugging output in logs (sets DEBUG log level output)
+#debug = True
+db_auto_create = True
+
+# Address to bind the API server
+bind_host = 0.0.0.0
+
+# Port to bind the API server to
+bind_port = 9311
+
+# Host name, for use in HATEOAS-style references
+#  Note: Typically this would be the load balanced endpoint that clients would use
+#  communicate back with this service.
+# If a deployment wants to derive host from wsgi request instead then make this
+# blank. Blank is needed to override default config value which is
+# 'http://localhost:9311'.
+host_href = http://localhost:9311
+
+# Log to this file. Make sure you do not set the same log
+# file for both the API and registry servers!
+#log_file = /var/log/barbican/api.log
+
+# Backlog requests when creating socket
+backlog = 4096
+
+# TCP_KEEPIDLE value in seconds when creating socket.
+# Not supported on OS X.
+#tcp_keepidle = 600
+
+# Maximum allowed http request size against the barbican-api
+max_allowed_secret_in_bytes = 10000
+max_allowed_request_size_in_bytes = 1000000
+
+# SQLAlchemy connection string for the reference implementation
+# registry server. Any valid SQLAlchemy connection string is fine.
+# See: http://www.sqlalchemy.org/docs/05/reference/sqlalchemy/connections.html#sqlalchemy.create_engine
+# Uncomment this for local dev, putting db in project directory:
+#sql_connection = sqlite:///barbican.sqlite
+# Note: For absolute addresses, use '////' slashes after 'sqlite:'
+# Uncomment for a more global development environment
+sql_connection = mysql+pymysql://barbican:avi123@localhost/barbican
+
+# Period in seconds after which SQLAlchemy should reestablish its connection
+# to the database.
+#
+# MySQL uses a default `wait_timeout` of 8 hours, after which it will drop
+# idle connections. This can result in 'MySQL Gone Away' exceptions. If you
+# notice this, you can lower this value to ensure that SQLAlchemy reconnects
+# before MySQL can drop the connection.
+sql_idle_timeout = 3600
+
+# Accepts a class imported from the sqlalchemy.pool module, and handles the
+# details of building the pool for you. If commented out, SQLAlchemy
+# will select based on the database dialect. Other options are QueuePool
+# (for SQLAlchemy-managed connections) and NullPool (to disabled SQLAlchemy
+# management of connections).
+# See http://docs.sqlalchemy.org/en/latest/core/pooling.html for more details.
+#sql_pool_class = QueuePool
+
+# Show SQLAlchemy pool-related debugging output in logs (sets DEBUG log level
+# output) if specified.
+#sql_pool_logging = True
+
+# Size of pool used by SQLAlchemy. This is the largest number of connections
+# that will be kept persistently in the pool. Can be set to 0 to indicate no
+# size limit. To disable pooling, use a NullPool with sql_pool_class instead.
+# Comment out to allow SQLAlchemy to select the default.
+#sql_pool_size = 5
+
+# The maximum overflow size of the pool used by SQLAlchemy. When the number of
+# checked-out connections reaches the size set in sql_pool_size, additional
+# connections will be returned up to this limit. It follows then that the
+# total number of simultaneous connections the pool will allow is
+# sql_pool_size + sql_pool_max_overflow. Can be set to -1 to indicate no
+# overflow limit, so no limit will be placed on the total number of concurrent
+# connections. Comment out to allow SQLAlchemy to select the default.
+#sql_pool_max_overflow = 10
+
+# Default page size for the 'limit' paging URL parameter.
+default_limit_paging = 10
+
+# Maximum page size for the 'limit' paging URL parameter.
+max_limit_paging = 100
+
+# Role used to identify an authenticated user as administrator
+#admin_role = admin
+
+# Allow unauthenticated users to access the API with read-only
+# privileges. This only applies when using ContextMiddleware.
+#allow_anonymous_access = False
+
+# Allow access to version 1 of barbican api
+#enable_v1_api = True
+
+# Allow access to version 2 of barbican api
+#enable_v2_api = True
+
+# ================= SSL Options ===============================
+
+# Certificate file to use when starting API server securely
+#cert_file = /path/to/certfile
+
+# Private key file to use when starting API server securely
+#key_file = /path/to/keyfile
+
+# CA certificate file to use to verify connecting clients
+#ca_file = /path/to/cafile
+
+# ================= Security Options ==========================
+
+# AES key for encrypting store 'location' metadata, including
+# -- if used -- Swift or S3 credentials
+# Should be set to a random string of length 16, 24 or 32 bytes
+#metadata_encryption_key = <16, 24 or 32 char registry metadata key>
+
+# ================= Queue Options - oslo.messaging ==========================
+
+[oslo_messaging_rabbit]
+
+# Rabbit and HA configuration:
+amqp_durable_queues = True
+rabbit_userid=guest
+rabbit_password=guest
+rabbit_ha_queues = True
+rabbit_port=5672
+
+# For HA, specify queue nodes in cluster, comma delimited:
+#   For example: rabbit_hosts=192.168.50.8:5672, 192.168.50.9:5672
+rabbit_hosts=localhost:5672
+
+# For HA, specify queue nodes in cluster as 'user@host:5672', comma delimited, ending with '/offset':
+#   For example: transport_url = rabbit://guest@192.168.50.8:5672,guest@192.168.50.9:5672/
+#   DO NOT USE THIS, due to '# FIXME(markmc): support multiple hosts' in oslo/messaging/_drivers/amqpdriver.py
+# transport_url = rabbit://guest@localhost:5672/
+transport_url = rabbit://openstack:avi123@localhost
+
+
+[oslo_messaging_notifications]
+# oslo notification driver for sending audit events via audit middleware.
+# Meaningful only when middleware is enabled in barbican paste ini file.
+# This is oslo config MultiStrOpt so can be defined multiple times in case
+# there is need to route audit event to messaging as well as log.
+# driver = messagingv2
+# driver = log
+
+
+# ======== OpenStack policy - oslo_policy ===============
+
+[oslo_policy]
+
+# ======== OpenStack policy integration
+# JSON file representing policy (string value)
+policy_file=/etc/barbican/policy.json
+
+# Rule checked when requested rule is not found (string value)
+policy_default_rule=default
+
+
+# ================= Queue Options - Application ==========================
+
+[queue]
+# Enable queuing asynchronous messaging.
+#   Set false to invoke worker tasks synchronously (i.e. no-queue standalone mode)
+enable = False
+
+# Namespace for the queue
+namespace = 'barbican'
+
+# Topic for the queue
+topic = 'barbican.workers'
+
+# Version for the task API
+version = '1.1'
+
+# Server name for RPC service
+server_name = 'barbican.queue'
+
+# Number of asynchronous worker processes.
+# When greater than 1, then that many additional worker processes are
+# created for asynchronous worker functionality.
+asynchronous_workers = 1
+
+# ================= Retry/Scheduler Options ==========================
+
+[retry_scheduler]
+# Seconds (float) to wait between starting retry scheduler
+initial_delay_seconds = 10.0
+
+# Seconds (float) to wait between starting retry scheduler
+periodic_interval_max_seconds = 10.0
+
+
+# ====================== Quota Options ===============================
+
+[quotas]
+# For each resource, the default maximum number that can be used for
+# a project is set below.  This value can be overridden for each
+# project through the API.  A negative value means no limit.  A zero
+# value effectively disables the resource.
+
+# default number of secrets allowed per project
+quota_secrets = -1
+
+# default number of orders allowed per project
+quota_orders = -1
+
+# default number of containers allowed per project
+quota_containers = -1
+
+# default number of consumers allowed per project
+quota_consumers = -1
+
+# default number of CAs allowed per project
+quota_cas = -1
+
+# ================= Keystone Notification Options - Application ===============
+
+[keystone_notifications]
+
+# Keystone notification functionality uses transport related configuration
+# from barbican common configuration as defined under
+# 'Queue Options - oslo.messaging' comments.
+# The HA related configuration is also shared with notification server.
+
+# True enables keystone notification listener functionality.
+enable = False
+
+# The default exchange under which topics are scoped.
+# May be overridden by an exchange name specified in the transport_url option.
+control_exchange = 'openstack'
+
+# Keystone notification queue topic name.
+# This name needs to match one of values mentioned in Keystone deployment's
+# 'notification_topics' configuration e.g.
+#      notification_topics=notifications, barbican_notifications
+# Multiple servers may listen on a topic and messages will be dispatched to one
+# of the servers in a round-robin fashion. That's why Barbican service should
+# have its own dedicated notification queue so that it receives all of Keystone
+# notifications.
+topic = 'notifications'
+
+# True enables requeue feature in case of notification processing error.
+# Enable this only when underlying transport supports this feature.
+allow_requeue = False
+
+# Version of tasks invoked via notifications
+version = '1.0'
+
+# Define the number of max threads to be used for notification server
+# processing functionality.
+thread_pool_size = 10
+
+# ================= Secret Store Plugin ===================
+[secretstore]
+namespace = barbican.secretstore.plugin
+enabled_secretstore_plugins = store_crypto
+
+# ================= Crypto plugin ===================
+[crypto]
+namespace = barbican.crypto.plugin
+enabled_crypto_plugins = simple_crypto
+
+[simple_crypto_plugin]
+# the kek should be a 32-byte value which is base64 encoded
+kek = 'YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY='
+
+# User friendly plugin name
+# plugin_name = 'Software Only Crypto'
+
+[dogtag_plugin]
+pem_path = '/etc/barbican/kra_admin_cert.pem'
+dogtag_host = localhost
+dogtag_port = 8443
+nss_db_path = '/etc/barbican/alias'
+nss_db_path_ca = '/etc/barbican/alias-ca'
+nss_password = 'password123'
+simple_cmc_profile = 'caOtherCert'
+ca_expiration_time = 1
+plugin_working_dir = '/etc/barbican/dogtag'
+
+# User friendly plugin name
+# plugin_name = 'Dogtag KRA'
+
+
+[p11_crypto_plugin]
+# Path to vendor PKCS11 library
+library_path = '/usr/lib/libCryptoki2_64.so'
+# Password to login to PKCS11 session
+login = 'mypassword'
+# Label to identify master KEK in the HSM (must not be the same as HMAC label)
+mkek_label = 'an_mkek'
+# Length in bytes of master KEK
+mkek_length = 32
+# Label to identify HMAC key in the HSM (must not be the same as MKEK label)
+hmac_label = 'my_hmac_label'
+# HSM Slot id (Should correspond to a configured PKCS11 slot). Default: 1
+# slot_id = 1
+# Enable Read/Write session with the HSM?
+# rw_session = True
+# Length of Project KEKs to create
+# pkek_length = 32
+# How long to cache unwrapped Project KEKs
+# pkek_cache_ttl = 900
+# Max number of items in pkek cache
+# pkek_cache_limit = 100
+
+# User friendly plugin name
+# plugin_name = 'PKCS11 HSM'
+
+
+# ================== KMIP plugin =====================
+[kmip_plugin]
+username = 'admin'
+password = 'password'
+host = localhost
+port = 5696
+keyfile = '/path/to/certs/cert.key'
+certfile = '/path/to/certs/cert.crt'
+ca_certs = '/path/to/certs/LocalCA.crt'
+
+# User friendly plugin name
+# plugin_name = 'KMIP HSM'
+
+
+# ================= Certificate plugin ===================
+
+# DEPRECATION WARNING: The Certificates Plugin has been deprecated
+# and will be removed in the P release.
+
+[certificate]
+namespace = barbican.certificate.plugin
+enabled_certificate_plugins = simple_certificate
+enabled_certificate_plugins = snakeoil_ca
+
+[certificate_event]
+namespace = barbican.certificate.event.plugin
+enabled_certificate_event_plugins = simple_certificate_event
+
+[snakeoil_ca_plugin]
+ca_cert_path = /etc/barbican/snakeoil-ca.crt
+ca_cert_key_path = /etc/barbican/snakeoil-ca.key
+ca_cert_chain_path = /etc/barbican/snakeoil-ca.chain
+ca_cert_pkcs7_path = /etc/barbican/snakeoil-ca.p7b
+subca_cert_key_directory=/etc/barbican/snakeoil-cas
+
+# ========================================================
+
+[cors]
+
+#
+# From oslo.middleware.cors
+#
+
+# Indicate whether this resource may be shared with the domain
+# received in the requests "origin" header. (list value)
+#allowed_origin = <None>
+
+# Indicate that the actual request can include user credentials
+# (boolean value)
+#allow_credentials = true
+
+# Indicate which headers are safe to expose to the API. Defaults to
+# HTTP Simple Headers. (list value)
+#expose_headers = X-Auth-Token, X-Openstack-Request-Id, X-Project-Id, X-Identity-Status, X-User-Id, X-Storage-Token, X-Domain-Id, X-User-Domain-Id, X-Project-Domain-Id, X-Roles
+
+# Maximum cache age of CORS preflight requests. (integer value)
+#max_age = 3600
+
+# Indicate which methods can be used during the actual request. (list
+# value)
+#allow_methods = GET,PUT,POST,DELETE,PATCH
+
+# Indicate which header field names may be used during the actual
+# request. (list value)
+#allow_headers = X-Auth-Token, X-Openstack-Request-Id, X-Project-Id, X-Identity-Status, X-User-Id, X-Storage-Token, X-Domain-Id, X-User-Domain-Id, X-Project-Domain-Id, X-Roles
+
+
+[cors.subdomain]
+
+#
+# From oslo.middleware.cors
+#
+
+# Indicate whether this resource may be shared with the domain
+# received in the requests "origin" header. (list value)
+#allowed_origin = <None>
+
+# Indicate that the actual request can include user credentials
+# (boolean value)
+#allow_credentials = true
+
+# Indicate which headers are safe to expose to the API. Defaults to
+# HTTP Simple Headers. (list value)
+#expose_headers = X-Auth-Token, X-Openstack-Request-Id, X-Project-Id, X-Identity-Status, X-User-Id, X-Storage-Token, X-Domain-Id, X-User-Domain-Id, X-Project-Domain-Id, X-Roles
+
+# Maximum cache age of CORS preflight requests. (integer value)
+#max_age = 3600
+
+# Indicate which methods can be used during the actual request. (list
+# value)
+#allow_methods = GET,PUT,POST,DELETE,PATCH
+
+# Indicate which header field names may be used during the actual
+# request. (list value)
+#allow_headers = X-Auth-Token, X-Openstack-Request-Id, X-Project-Id, X-Identity-Status, X-User-Id, X-Storage-Token, X-Domain-Id, X-User-Domain-Id, X-Project-Domain-Id, X-Roles
+
+
+[oslo_middleware]
+
+#
+# From oslo.middleware.http_proxy_to_wsgi
+#
+
+# Wether the application is behind a proxy or not. This determines if
+# the middleware should parse the headers or not. (boolean value)
+#enable_proxy_headers_parsing = false
+
+
+[keystone_authtoken]
+www_authenticate_uri = http://localhost:5000
+auth_url = http://localhost:5000
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = barbican
+password = avi123
+
+
+#
+# From keystonemiddleware.auth_token
+#
+
+# Complete "public" Identity API endpoint. This endpoint should not be an
+# "admin" endpoint, as it should be accessible by all end users. Unauthenticated
+# clients are redirected to this endpoint to authenticate. Although this
+# endpoint should  ideally be unversioned, client support in the wild varies.
+# If you're using a versioned v2 endpoint here, then this  should *not* be the
+# same endpoint the service user utilizes  for validating tokens, because normal
+# end users may not be  able to reach that endpoint. (string value)
+#auth_uri = <None>
+
+# API version of the admin Identity API endpoint. (string value)
+#auth_version = <None>
+
+# Do not handle authorization requests within the middleware, but delegate the
+# authorization decision to downstream WSGI components. (boolean value)
+#delay_auth_decision = false
+
+# Request timeout value for communicating with Identity API server. (integer
+# value)
+#http_connect_timeout = <None>
+
+# How many times are we trying to reconnect when communicating with Identity API
+# Server. (integer value)
+#http_request_max_retries = 3
+
+# Request environment key where the Swift cache object is stored. When
+# auth_token middleware is deployed with a Swift cache, use this option to have
+# the middleware share a caching backend with swift. Otherwise, use the
+# ``memcached_servers`` option instead. (string value)
+#cache = <None>
+
+# Required if identity server requires client certificate (string value)
+#certfile = <None>
+
+# Required if identity server requires client certificate (string value)
+#keyfile = <None>
+
+# A PEM encoded Certificate Authority to use when verifying HTTPs connections.
+# Defaults to system CAs. (string value)
+#cafile = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# The region in which the identity server can be found. (string value)
+#region_name = <None>
+
+# Directory used to cache files related to PKI tokens. (string value)
+#signing_dir = <None>
+
+# Optionally specify a list of memcached server(s) to use for caching. If left
+# undefined, tokens will instead be cached in-process. (list value)
+# Deprecated group/name - [keystone_authtoken]/memcache_servers
+#memcached_servers = <None>
+
+# In order to prevent excessive effort spent validating tokens, the middleware
+# caches previously-seen tokens for a configurable duration (in seconds). Set to
+# -1 to disable caching completely. (integer value)
+#token_cache_time = 300
+
+# Determines the frequency at which the list of revoked tokens is retrieved from
+# the Identity service (in seconds). A high number of revocation events combined
+# with a low cache duration may significantly reduce performance. Only valid for
+# PKI tokens. (integer value)
+#revocation_cache_time = 10
+
+# (Optional) If defined, indicate whether token data should be authenticated or
+# authenticated and encrypted. If MAC, token data is authenticated (with HMAC)
+# in the cache. If ENCRYPT, token data is encrypted and authenticated in the
+# cache. If the value is not one of these options or empty, auth_token will
+# raise an exception on initialization. (string value)
+# Allowed values: None, MAC, ENCRYPT
+#memcache_security_strategy = None
+
+# (Optional, mandatory if memcache_security_strategy is defined) This string is
+# used for key derivation. (string value)
+#memcache_secret_key = <None>
+
+# (Optional) Number of seconds memcached server is considered dead before it is
+# tried again. (integer value)
+#memcache_pool_dead_retry = 300
+
+# (Optional) Maximum total number of open connections to every memcached server.
+# (integer value)
+#memcache_pool_maxsize = 10
+
+# (Optional) Socket timeout in seconds for communicating with a memcached
+# server. (integer value)
+#memcache_pool_socket_timeout = 3
+
+# (Optional) Number of seconds a connection to memcached is held unused in the
+# pool before it is closed. (integer value)
+#memcache_pool_unused_timeout = 60
+
+# (Optional) Number of seconds that an operation will wait to get a memcached
+# client connection from the pool. (integer value)
+#memcache_pool_conn_get_timeout = 10
+
+# (Optional) Use the advanced (eventlet safe) memcached client pool. The
+# advanced pool will only work under python 2.x. (boolean value)
+#memcache_use_advanced_pool = false
+
+# (Optional) Indicate whether to set the X-Service-Catalog header. If False,
+# middleware will not ask for service catalog on token validation and will not
+# set the X-Service-Catalog header. (boolean value)
+#include_service_catalog = true
+
+# Used to control the use and type of token binding. Can be set to: "disabled"
+# to not check token binding. "permissive" (default) to validate binding
+# information if the bind type is of a form known to the server and ignore it if
+# not. "strict" like "permissive" but if the bind type is unknown the token will
+# be rejected. "required" any form of token binding is needed to be allowed.
+# Finally the name of a binding method that must be present in tokens. (string
+# value)
+#enforce_token_bind = permissive
+
+# If true, the revocation list will be checked for cached tokens. This requires
+# that PKI tokens are configured on the identity server. (boolean value)
+#check_revocations_for_cached = false
+
+# Hash algorithms to use for hashing PKI tokens. This may be a single algorithm
+# or multiple. The algorithms are those supported by Python standard
+# hashlib.new(). The hashes will be tried in the order given, so put the
+# preferred one first for performance. The result of the first hash will be
+# stored in the cache. This will typically be set to multiple values only while
+# migrating from a less secure algorithm to a more secure one. Once all the old
+# tokens are expired this option should be set to a single value for better
+# performance. (list value)
+#hash_algorithms = md5
+
+# Authentication type to load (string value)
+# Deprecated group/name - [keystone_authtoken]/auth_plugin
+#auth_type = <None>
+
+# Config Section from which to load plugin specific options (string value)
+#auth_section = <None>

--- a/rocky/custom-post-install.sh
+++ b/rocky/custom-post-install.sh
@@ -1,0 +1,23 @@
+set -e
+set -x
+# get IP of ens4
+# use it to populate pool start, end, gw, cidr
+interface=ens4
+# Run in subshell to avoid exiting this script
+# (dhclient -r $interface; dhclient $interface)
+my_ip_pref=`ifconfig $interface | grep "inet" | grep -v "inet6" | awk '{split($2, b, "."); printf("%s.%s.%s.", b[1], b[2], b[3]);}'`
+
+# for floating IP and external connectivity
+# choose a small pool from the subnet from ens4
+POOL_START=${my_ip_pref}${1:-100}
+POOL_END=${my_ip_pref}${2:-120}
+GW=${my_ip_pref}1
+CIDR=${my_ip_pref}0/24
+
+source /root/admin-openrc.sh
+neutron net-create --shared --router:external --provider:physical_network provider --provider:network_type flat provider1
+neutron subnet-create --name provider1-v4 --ip-version 4 \
+   --allocation-pool start=$POOL_START,end=$POOL_END \
+   --gateway $GW --dns-nameserver 8.8.4.4 provider1 \
+   $CIDR 
+

--- a/rocky/demo-openrc.sh
+++ b/rocky/demo-openrc.sh
@@ -1,0 +1,8 @@
+export OS_PROJECT_DOMAIN_NAME=default
+export OS_USER_DOMAIN_NAME=default
+export OS_PROJECT_NAME=demo
+export OS_USERNAME=demo
+export OS_PASSWORD=avi123
+export OS_AUTH_URL=http://localhost:5000/v3
+export OS_IDENTITY_API_VERSION=3
+export OS_IMAGE_API_VERSION=2

--- a/rocky/dhcp_agent.ini
+++ b/rocky/dhcp_agent.ini
@@ -1,0 +1,216 @@
+[DEFAULT]
+interface_driver = linuxbridge
+dhcp_driver = neutron.agent.linux.dhcp.Dnsmasq
+enable_isolated_metadata = true
+
+#
+# From neutron.base.agent
+#
+
+# Name of Open vSwitch bridge to use (string value)
+#ovs_integration_bridge = br-int
+
+# Uses veth for an OVS interface or not. Support kernels with limited namespace
+# support (e.g. RHEL 6.5) so long as ovs_use_veth is set to True. (boolean
+# value)
+#ovs_use_veth = false
+
+# MTU setting for device. This option will be removed in Newton. Please use the
+# system-wide global_physnet_mtu setting which the agents will take into
+# account when wiring VIFs. (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#network_device_mtu = <None>
+
+# The driver used to manage the virtual interface. (string value)
+#interface_driver = <None>
+
+# Timeout in seconds for ovs-vsctl commands. If the timeout expires, ovs
+# commands will fail with ALARMCLOCK error. (integer value)
+#ovs_vsctl_timeout = 10
+
+#
+# From neutron.dhcp.agent
+#
+
+# The DHCP agent will resync its state with Neutron to recover from any
+# transient notification or RPC errors. The interval is number of seconds
+# between attempts. (integer value)
+#resync_interval = 5
+
+# The driver used to manage the DHCP server. (string value)
+#dhcp_driver = neutron.agent.linux.dhcp.Dnsmasq
+
+# The DHCP server can assist with providing metadata support on isolated
+# networks. Setting this value to True will cause the DHCP server to append
+# specific host routes to the DHCP request. The metadata service will only be
+# activated when the subnet does not contain any router port. The guest
+# instance must be configured to request host routes via DHCP (Option 121).
+# This option doesn't have any effect when force_metadata is set to True.
+# (boolean value)
+#enable_isolated_metadata = false
+
+# In some cases the Neutron router is not present to provide the metadata IP
+# but the DHCP server can be used to provide this info. Setting this value will
+# force the DHCP server to append specific host routes to the DHCP request. If
+# this option is set, then the metadata service will be activated for all the
+# networks. (boolean value)
+#force_metadata = false
+
+# Allows for serving metadata requests coming from a dedicated metadata access
+# network whose CIDR is 169.254.169.254/16 (or larger prefix), and is connected
+# to a Neutron router from which the VMs send metadata:1 request. In this case
+# DHCP Option 121 will not be injected in VMs, as they will be able to reach
+# 169.254.169.254 through a router. This option requires
+# enable_isolated_metadata = True. (boolean value)
+#enable_metadata_network = false
+
+# Number of threads to use during sync process. Should not exceed connection
+# pool size configured on server. (integer value)
+#num_sync_threads = 4
+
+# Location to store DHCP server config files. (string value)
+#dhcp_confs = $state_path/dhcp
+
+# Domain to use for building the hostnames. This option is deprecated. It has
+# been moved to neutron.conf as dns_domain. It will be removed in a future
+# release. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#dhcp_domain = openstacklocal
+
+# Override the default dnsmasq settings with this file. (string value)
+#dnsmasq_config_file =
+
+# Comma-separated list of the DNS servers which will be used as forwarders.
+# (list value)
+# Deprecated group/name - [DEFAULT]/dnsmasq_dns_server
+#dnsmasq_dns_servers = <None>
+
+# Base log dir for dnsmasq logging. The log contains DHCP and DNS log
+# information and is useful for debugging issues with either DHCP or DNS. If
+# this section is null, disable dnsmasq log. (string value)
+#dnsmasq_base_log_dir = <None>
+
+# Enables the dnsmasq service to provide name resolution for instances via DNS
+# resolvers on the host running the DHCP agent. Effectively removes the '--no-
+# resolv' option from the dnsmasq process arguments. Adding custom DNS
+# resolvers to the 'dnsmasq_dns_servers' option disables this feature. (boolean
+# value)
+#dnsmasq_local_resolv = false
+
+# Limit number of leases to prevent a denial-of-service. (integer value)
+#dnsmasq_lease_max = 16777216
+
+# Use broadcast in DHCP replies. (boolean value)
+#dhcp_broadcast_reply = false
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of the default
+# INFO level. (boolean value)
+#debug = false
+
+# If set to false, the logging level will be set to WARNING instead of the
+# default INFO level. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#verbose = true
+
+# The name of a logging configuration file. This file is appended to any
+# existing logging configuration files. For details about logging configuration
+# files, see the Python logging module documentation. Note that when logging
+# configuration files are used then all logging configuration is set in the
+# configuration file and other logging configuration options are ignored (for
+# example, logging_context_format_string). (string value)
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set. (string
+# value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default is set,
+# logging will go to stderr as defined by use_stderr. This option is ignored if
+# log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths. This option
+# is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is moved or
+# removed this handler will open a new log file with specified path
+# instantaneously. It makes sense only if log_file option is specified and
+# Linux platform is used. This option is ignored if log_config_append is set.
+# (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and will be
+# changed later to honor RFC5424. This option is ignored if log_config_append
+# is set. (boolean value)
+#use_syslog = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Log output to standard error. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_stderr = true
+
+# Format string to use for log messages with context. (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined. (string
+# value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the message
+# is DEBUG. (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. (string value)
+#logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is ignored
+# if log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,dogpile.core.dogpile=INFO
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message. (string
+# value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message. (string
+# value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false
+
+
+[AGENT]
+
+#
+# From neutron.base.agent
+#
+
+# Seconds between nodes reporting state to server; should be less than
+# agent_down_time, best if it is half or less than agent_down_time. (floating
+# point value)
+#report_interval = 30
+
+# Log agent heartbeats (boolean value)
+#log_agent_heartbeats = false

--- a/rocky/glance-api.conf
+++ b/rocky/glance-api.conf
@@ -1,0 +1,38 @@
+[DEFAULT]
+[cors]
+[cors.subdomain]
+[image_format]
+disk_formats = ami,ari,aki,vhd,vhdx,vmdk,raw,qcow2,vdi,iso,ploop.root-tar
+[matchmaker_redis]
+[oslo_concurrency]
+[oslo_messaging_amqp]
+[oslo_messaging_kafka]
+[oslo_messaging_notifications]
+[oslo_messaging_rabbit]
+[oslo_messaging_zmq]
+[oslo_middleware]
+[oslo_policy]
+[profiler]
+[store_type_location_strategy]
+[task]
+[taskflow_executor]
+[database]
+backend = sqlalchemy
+connection = mysql+pymysql://glance:avi123@localhost/glance
+[glance_store]
+stores = file,http
+default_store = file
+filesystem_store_datadir = /var/lib/glance/images/
+[image_format]
+[keystone_authtoken]
+auth_uri = http://localhost:5000
+auth_url = http://localhost:5000
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = glance
+password = avi123 
+[paste_deploy]
+flavor = keystone

--- a/rocky/glance-registry.conf
+++ b/rocky/glance-registry.conf
@@ -1,0 +1,25 @@
+[DEFAULT]
+[matchmaker_redis]
+[oslo_messaging_amqp]
+[oslo_messaging_kafka]
+[oslo_messaging_notifications]
+[oslo_messaging_rabbit]
+[oslo_messaging_zmq]
+[oslo_policy]
+[profiler]
+[database]
+connection = mysql+pymysql://glance:avi123@localhost/glance
+backend = sqlalchemy
+[glance_store]
+[keystone_authtoken]
+auth_uri = http://localhost:5000
+auth_url = http://localhost:5000
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = glance
+password = avi123 
+[paste_deploy]
+flavor = keystone

--- a/rocky/heat.conf
+++ b/rocky/heat.conf
@@ -1,0 +1,73 @@
+[DEFAULT]
+[auth_password]
+[clients]
+[clients_aodh]
+[clients_barbican]
+[clients_ceilometer]
+[clients_cinder]
+[clients_designate]
+[clients_glance]
+[clients_heat]
+[clients_keystone]
+[clients_magnum]
+[clients_manila]
+[clients_mistral]
+[clients_monasca]
+[clients_neutron]
+[clients_nova]
+[clients_sahara]
+[clients_senlin]
+[clients_swift]
+[clients_trove]
+[clients_zaqar]
+[cors]
+[cors.subdomain]
+[ec2authtoken]
+[eventlet_opts]
+[healthcheck]
+[heat_api]
+[heat_api_cfn]
+[heat_api_cloudwatch]
+[keystone_authtoken]
+[matchmaker_redis]
+[oslo_messaging_amqp]
+[oslo_messaging_kafka]
+[oslo_messaging_notifications]
+[oslo_messaging_rabbit]
+[oslo_messaging_zmq]
+[oslo_middleware]
+[oslo_policy]
+[paste_deploy]
+[profiler]
+[revision]
+[ssl]
+[volumes]
+[DEFAULT]
+transport_url = rabbit://openstack:avi123@localhost
+heat_metadata_server_url = http://localhost:8000
+heat_waitcondition_server_url = http://localhost:8000/v1/waitcondition
+stack_domain_admin = heat_domain_admin
+stack_domain_admin_password = avi123
+stack_user_domain_name = heat
+[database]
+connection = mysql+pymysql://heat:avi123@localhost/heat
+[keystone_authtoken]
+auth_uri = http://localhost:5000
+auth_url = http://localhost:5000
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = heat
+password = avi123
+[trustee]
+auth_type = password
+auth_url = http://localhost:5000
+username = heat
+password = avi123
+user_domain_name = default
+[clients_keystone]
+auth_uri = http://localhost:5000
+[ec2authtoken]
+auth_uri = http://localhost:5000/v3

--- a/rocky/install-lbaasv2.sh
+++ b/rocky/install-lbaasv2.sh
@@ -1,0 +1,79 @@
+set -x
+set -e
+
+# explicitly set locale to avoid any pip install issues
+export LC_ALL=C
+
+cp /root/files/demo-openrc.sh /root/
+cp /root/files/admin-openrc.sh /root/
+source /root/admin-openrc.sh
+
+export DEBIAN_FRONTEND=noninteractive
+interface=ens3
+my_ip=`ifconfig $interface | grep "inet" | grep -v "inet6" | awk '{print $2}'`
+
+# lbaas
+git clone https://github.com/openstack/neutron-lbaas
+cd /root/neutron-lbaas
+git checkout origin/stable/rocky -b rocky
+python setup.py sdist
+pip install dist/*tar.gz
+cd -
+sed -i "s/service_plugins = router/service_plugins = router,neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2/g" /etc/neutron/neutron.conf
+cat << EOF >> /etc/neutron/neutron.conf
+[service_providers]
+service_provider = LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
+
+[service_auth]
+auth_version = 3
+admin_password = avi123
+admin_user = admin
+admin_tenant_name = demo
+#auth_uri = http://127.0.0.1:5000/v2.0
+auth_url = http://127.0.0.1:5000/v3
+admin_user_domain = default
+admin_project_domain = default
+
+EOF
+neutron-db-manage --subproject neutron-lbaas upgrade head
+service neutron-server restart
+
+# lbaas-dashboard
+git clone https://git.openstack.org/openstack/neutron-lbaas-dashboard
+cd neutron-lbaas-dashboard
+git checkout origin/stable/rocky -b rocky
+python setup.py sdist
+pip install dist/*tar.gz
+cd -
+cp neutron-lbaas-dashboard/neutron_lbaas_dashboard/enabled/_1481_project_ng_loadbalancersv2_panel.py /usr/share/openstack-dashboard/openstack_dashboard/local/enabled/
+cd /usr/share/openstack-dashboard/
+./manage.py collectstatic --noinput
+./manage.py compress
+cd -
+service apache2 restart
+
+# barbican
+mysql -u root --password="avi123" -e "CREATE DATABASE barbican;"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON barbican.* TO 'barbican'@'localhost' IDENTIFIED BY 'avi123';"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON barbican.* TO 'barbican'@'%' IDENTIFIED BY 'avi123';"
+
+openstack user create --domain default --password avi123 barbican
+openstack role add --project service --user barbican admin
+openstack role create creator
+openstack role add --project service --user barbican creator
+openstack role add --project admin --user admin creator
+openstack role add --project demo --user demo creator
+
+openstack service create --name barbican   --description "Key Manager" key-manager
+openstack endpoint create --region RegionOne   key-manager public http://$my_ip:9311
+openstack endpoint create --region RegionOne   key-manager internal http://$my_ip:9311
+openstack endpoint create --region RegionOne   key-manager admin http://$my_ip:9311
+apt-get install barbican-api barbican-keystone-listener barbican-worker -y
+cp /root/files/barbican.conf /etc/barbican/
+cp /root/files/barbican-api-paste.ini /etc/barbican/
+sed -i "s/localhost:9311/$my_ip:9311/g" /etc/barbican/barbican.conf
+sed -i "s/db_auto_create = True/db_auto_create = False/g" /etc/barbican/barbican.conf
+su -s /bin/sh -c "barbican-manage db upgrade" barbican
+service barbican-keystone-listener restart
+service barbican-worker restart
+service apache2 restart

--- a/rocky/installer.sh
+++ b/rocky/installer.sh
@@ -1,0 +1,204 @@
+set -x
+set -e
+
+export LC_ALL=C
+
+cp /root/files/demo-openrc.sh /root/
+cp /root/files/admin-openrc.sh /root/
+source /root/admin-openrc.sh
+
+apt-get -y update && apt-get -y upgrade
+add-apt-repository -y cloud-archive:rocky
+apt-get --yes install software-properties-common
+apt-get install -y python-openstackclient  python-pip git
+apt-get install -y ssh-client
+
+# install mysql
+export DEBIAN_FRONTEND=noninteractive
+apt-get -y install mariadb-server python-pymysql && service mysql restart
+mysqladmin -u root password avi123
+cp /root/files/mysqld_openstack.cnf /etc/mysql/mariadb.conf.d/99-openstack.cnf
+service mysql restart
+
+# install rabbitmq
+apt-get -y install rabbitmq-server
+service rabbitmq-server start
+rabbitmqctl add_user openstack avi123
+rabbitmqctl set_permissions openstack ".*" ".*" ".*"
+
+# get my ip
+interface=ens3
+my_ip=`ifconfig $interface | grep "inet" | grep -v "inet6" | awk '{print $2}'`
+
+# install keystone
+mysql -u root --password="avi123" -e "CREATE DATABASE keystone;"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'localhost' IDENTIFIED BY 'avi123';"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'%' IDENTIFIED BY 'avi123';"
+# echo "manual" > /etc/init/keystone.override
+apt-get -y install keystone apache2 libapache2-mod-wsgi memcached python-memcache
+cp /root/files/keystone.conf /etc/keystone/
+su -s /bin/sh -c "keystone-manage db_sync" keystone
+keystone-manage fernet_setup --keystone-user keystone --keystone-group keystone
+keystone-manage credential_setup --keystone-user keystone --keystone-group keystone
+keystone-manage bootstrap --bootstrap-password avi123 \
+  --bootstrap-admin-url http://$my_ip:5000/v3/ \
+  --bootstrap-internal-url http://$my_ip:5000/v3/ \
+  --bootstrap-public-url http://$my_ip:5000/v3/ \
+  --bootstrap-region-id RegionOne
+
+service memcached restart
+if [ -f /etc/apache2/apache2.conf ]
+then
+    echo "ServerName localhost" >> /etc/apache2/apache2.conf
+else
+    service apache2 restart
+    echo "ServerName localhost" >> /etc/apache2/apache2.conf
+fi
+service apache2 restart
+rm -f /var/lib/keystone/keystone.db
+
+source /root/files/admin-openrc.sh
+openstack project create --domain default   --description "Service Project" service
+openstack project create --domain default   --description "Demo Project" demo
+openstack user create --domain default   --password avi123 demo
+openstack role create user
+openstack role add --project demo --user demo user
+
+# add glance
+mysql -u root --password="avi123" -e "CREATE DATABASE glance;" 
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON glance.* TO 'glance'@'localhost' IDENTIFIED BY 'avi123';"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON glance.* TO 'glance'@'%' IDENTIFIED BY 'avi123';"
+
+openstack user create --domain default --password avi123 glance
+openstack role add --project service --user glance admin
+
+openstack service create --name glance --description "OpenStack Image service" image
+openstack endpoint create --region RegionOne image public http://$my_ip:9292
+openstack endpoint create --region RegionOne image internal http://$my_ip:9292
+openstack endpoint create --region RegionOne image admin http://$my_ip:9292
+
+apt-get -y install glance
+cp /root/files/glance-api.conf /etc/glance/
+cp /root/files/glance-registry.conf /etc/glance/
+su -s /bin/sh -c "glance-manage db_sync" glance
+service glance-registry restart
+service glance-api restart
+
+#add nova: api, compute and other nova components 
+mysql -u root --password="avi123" -e "CREATE DATABASE nova;" 
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON nova.* TO 'nova'@'localhost' IDENTIFIED BY 'avi123';"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON nova.* TO 'nova'@'%' IDENTIFIED BY 'avi123';"
+
+mysql -u root --password="avi123" -e "CREATE DATABASE nova_api;" 
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON nova_api.* TO 'nova'@'localhost' IDENTIFIED BY 'avi123';"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON nova_api.* TO 'nova'@'%' IDENTIFIED BY 'avi123';"
+
+
+mysql -u root --password="avi123" -e "CREATE DATABASE nova_cell0;" 
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON nova_cell0.* TO 'nova'@'localhost' IDENTIFIED BY 'avi123';"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON nova_cell0.* TO 'nova'@'%' IDENTIFIED BY 'avi123';"
+
+openstack user create --domain default --password avi123 nova
+openstack role add --project service --user nova admin
+openstack service create --name nova --description "OpenStack Compute" compute
+openstack endpoint create --region RegionOne compute public http://$my_ip:8774/v2.1
+openstack endpoint create --region RegionOne compute internal http://$my_ip:8774/v2.1
+openstack endpoint create --region RegionOne compute admin http://$my_ip:8774/v2.1
+
+openstack user create --domain default --password avi123 placement
+openstack role add --project service --user placement admin
+openstack service create --name placement --description "Placement API" placement
+openstack endpoint create --region RegionOne placement public http://$my_ip:8778
+openstack endpoint create --region RegionOne placement internal http://$my_ip:8778
+openstack endpoint create --region RegionOne placement admin http://$my_ip:8778
+
+
+apt-get -y install nova-api nova-conductor nova-consoleauth \
+  nova-novncproxy nova-scheduler nova-placement-api python-novaclient
+cp /root/files/nova.conf /etc/nova/
+sed -i s/MY_IP/$my_ip/g /etc/nova/nova.conf
+su -s /bin/sh -c "nova-manage api_db sync" nova
+su -s /bin/sh -c "nova-manage cell_v2 map_cell0" nova
+su -s /bin/sh -c "nova-manage cell_v2 create_cell --name=cell1 --verbose" nova
+su -s /bin/sh -c "nova-manage db sync" nova
+nova-manage cell_v2 list_cells
+
+service nova-api restart
+service nova-consoleauth restart
+service nova-scheduler restart
+service nova-conductor restart
+service nova-novncproxy restart
+#nova compute
+apt-get install -y nova-compute
+service nova-compute restart
+openstack hypervisor list
+su -s /bin/sh -c "nova-manage cell_v2 discover_hosts --verbose" nova
+
+# add neutron service
+mysql -u root --password="avi123" -e "CREATE DATABASE neutron;"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON neutron.* TO 'neutron'@'localhost' IDENTIFIED BY 'avi123';"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON neutron.* TO 'neutron'@'%' IDENTIFIED BY 'avi123';"
+
+source /root/admin-openrc.sh
+openstack user create --domain default --password avi123 neutron
+openstack role add --project service --user neutron admin
+openstack service create --name neutron --description "OpenStack Networking" network
+openstack endpoint create --region RegionOne network public http://$my_ip:9696
+openstack endpoint create --region RegionOne network internal http://$my_ip:9696
+openstack endpoint create --region RegionOne network admin http://$my_ip:9696
+apt-get -y install neutron-server neutron-plugin-ml2 neutron-linuxbridge-agent neutron-dhcp-agent neutron-metadata-agent neutron-l3-agent
+cp /root/files/neutron.conf /etc/neutron/
+cp /root/files/ml2_conf.ini /etc/neutron/plugins/ml2/
+cp /root/files/linuxbridge_agent.ini /etc/neutron/plugins/ml2/
+sed -i s/OVERLAY_INTERFACE_IP_ADDRESS/$my_ip/g /etc/neutron/plugins/ml2/linuxbridge_agent.ini
+cp /root/files/l3_agent.ini /etc/neutron/
+cp /root/files/dhcp_agent.ini /etc/neutron/
+cp /root/files/metadata_agent.ini /etc/neutron/
+su -s /bin/sh -c "neutron-db-manage --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2_conf.ini upgrade head" neutron
+service nova-api restart
+service neutron-server restart
+service neutron-linuxbridge-agent restart
+service neutron-dhcp-agent restart
+service neutron-metadata-agent restart
+service neutron-l3-agent restart
+
+service nova-compute restart
+
+
+# dashboard
+
+apt-get install -y openstack-dashboard
+cp /root/files/local_settings.py /etc/openstack-dashboard/local_settings.py
+chown www-data /var/lib/openstack-dashboard/secret_key
+service apache2 reload
+
+# heat
+mysql -u root --password="avi123" -e "CREATE DATABASE heat;" 
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON heat.* TO 'heat'@'localhost' IDENTIFIED BY 'avi123';"
+mysql -u root --password="avi123" -e "GRANT ALL PRIVILEGES ON heat.* TO 'heat'@'%' IDENTIFIED BY 'avi123';"
+
+openstack user create --domain default --password avi123 heat
+openstack role add --project service --user heat admin
+openstack service create --name heat   --description "Orchestration" orchestration
+openstack service create --name heat-cfn   --description "Orchestration"  cloudformation
+openstack endpoint create --region RegionOne   orchestration public http://$my_ip:8004/v1/%\(tenant_id\)s
+openstack endpoint create --region RegionOne   orchestration internal http://$my_ip:8004/v1/%\(tenant_id\)s
+openstack endpoint create --region RegionOne   orchestration admin http://$my_ip:8004/v1/%\(tenant_id\)s
+openstack endpoint create --region RegionOne   cloudformation public http://$my_ip:8000/v1
+openstack endpoint create --region RegionOne   cloudformation internal http://$my_ip:8000/v1
+openstack endpoint create --region RegionOne   cloudformation admin http://$my_ip:8000/v1
+openstack domain create --description "Stack projects and users" heat
+openstack user create --domain heat --password avi123 heat_domain_admin
+openstack role add --domain heat --user-domain heat --user heat_domain_admin admin
+openstack role create heat_stack_owner
+openstack role add --project demo --user demo heat_stack_owner
+openstack role create heat_stack_user
+apt-get install heat-api heat-api-cfn heat-engine -y
+cp /root/files/heat.conf /etc/heat/
+su -s /bin/sh -c "heat-manage db_sync" heat
+
+service heat-api restart
+service heat-api-cfn restart
+service heat-engine restart
+
+chown horizon /var/lib/openstack-dashboard/secret_key

--- a/rocky/keystone.conf
+++ b/rocky/keystone.conf
@@ -1,0 +1,2952 @@
+[DEFAULT]
+
+#
+# From keystone
+#
+
+# Using this feature is *NOT* recommended. Instead, use the `keystone-manage
+# bootstrap` command. The value of this option is treated as a "shared secret"
+# that can be used to bootstrap Keystone through the API. This "token" does not
+# represent a user (it has no identity), and carries no explicit authorization
+# (it effectively bypasses most authorization checks). If set to `None`, the
+# value is ignored and the `admin_token` middleware is effectively disabled.
+# However, to completely disable `admin_token` in production (highly
+# recommended, as it presents a security risk), remove
+# `AdminTokenAuthMiddleware` (the `admin_token_auth` filter) from your paste
+# application pipelines (for example, in `keystone-paste.ini`). (string value)
+#admin_token = <None>
+
+# The base public endpoint URL for Keystone that is advertised to clients
+# (NOTE: this does NOT affect how Keystone listens for connections). Defaults
+# to the base host URL of the request. For example, if keystone receives a
+# request to `http://server:5000/v3/users`, then this will option will be
+# automatically treated as `http://server:5000`. You should only need to set
+# option if either the value of the base URL contains a path that keystone does
+# not automatically infer (`/prefix/v3`), or if the endpoint should be found on
+# a different host. (uri value)
+#public_endpoint = <None>
+
+# The base admin endpoint URL for Keystone that is advertised to clients (NOTE:
+# this does NOT affect how Keystone listens for connections). Defaults to the
+# base host URL of the request. For example, if keystone receives a request to
+# `http://server:35357/v3/users`, then this will option will be automatically
+# treated as `http://server:35357`. You should only need to set option if
+# either the value of the base URL contains a path that keystone does not
+# automatically infer (`/prefix/v3`), or if the endpoint should be found on a
+# different host. (uri value)
+#admin_endpoint = <None>
+
+# Maximum depth of the project hierarchy, excluding the project acting as a
+# domain at the top of the hierarchy. WARNING: Setting it to a large value may
+# adversely impact performance. (integer value)
+#max_project_tree_depth = 5
+
+# Limit the sizes of user & project ID/names. (integer value)
+#max_param_size = 64
+
+# Similar to `[DEFAULT] max_param_size`, but provides an exception for token
+# values. With Fernet tokens, this can be set as low as 255. With UUID tokens,
+# this should be set to 32). (integer value)
+#max_token_size = 255
+
+# Similar to the `[DEFAULT] member_role_name` option, this represents the
+# default role ID used to associate users with their default projects in the v2
+# API. This will be used as the explicit role where one is not specified by the
+# v2 API. You do not need to set this value unless you want keystone to use an
+# existing role with a different ID, other than the arbitrarily defined
+# `_member_` role (in which case, you should set `[DEFAULT] member_role_name`
+# as well). (string value)
+#member_role_id = 9fe2ff9ee4384b1894a90878d3e92bab
+
+# This is the role name used in combination with the `[DEFAULT] member_role_id`
+# option; see that option for more detail. You do not need to set this option
+# unless you want keystone to use an existing role (in which case, you should
+# set `[DEFAULT] member_role_id` as well). (string value)
+#member_role_name = _member_
+
+# The value passed as the keyword "rounds" to passlib's encrypt method. This
+# option represents a trade off between security and performance. Higher values
+# lead to slower performance, but higher security. Changing this option will
+# only affect newly created passwords as existing password hashes already have
+# a fixed number of rounds applied, so it is safe to tune this option in a
+# running cluster. For more information, see
+# https://pythonhosted.org/passlib/password_hash_api.html#choosing-the-right-
+# rounds-value (integer value)
+# Minimum value: 1000
+# Maximum value: 100000
+#crypt_strength = 10000
+
+# The maximum number of entities that will be returned in a collection. This
+# global limit may be then overridden for a specific driver, by specifying a
+# list_limit in the appropriate section (for example, `[assignment]`). No limit
+# is set by default. In larger deployments, it is recommended that you set this
+# to a reasonable number to prevent operations like listing all users and
+# projects from placing an unnecessary load on the system. (integer value)
+#list_limit = <None>
+
+# If set to true, strict password length checking is performed for password
+# manipulation. If a password exceeds the maximum length, the operation will
+# fail with an HTTP 403 Forbidden error. If set to false, passwords are
+# automatically truncated to the maximum length. (boolean value)
+#strict_password_check = false
+
+# DEPRECATED: The HTTP header used to determine the scheme for the original
+# request, even if it was removed by an SSL terminating proxy. (string value)
+# This option is deprecated for removal since N.
+# Its value may be silently ignored in the future.
+# Reason: This option has been deprecated in the N release and will be removed
+# in the P release. Use oslo.middleware.http_proxy_to_wsgi configuration
+# instead.
+#secure_proxy_ssl_header = HTTP_X_FORWARDED_PROTO
+
+# If set to true, then the server will return information in HTTP responses
+# that may allow an unauthenticated or authenticated user to get more
+# information than normal, such as additional details about why authentication
+# failed. This may be useful for debugging but is insecure. (boolean value)
+#insecure_debug = false
+
+# Default `publisher_id` for outgoing notifications. If left undefined,
+# Keystone will default to using the server's host name. (string value)
+#default_publisher_id = <None>
+
+# Define the notification format for identity service events. A `basic`
+# notification only has information about the resource being operated on. A
+# `cadf` notification has the same information, as well as information about
+# the initiator of the event. The `cadf` option is entirely backwards
+# compatible with the `basic` option, but is fully CADF-compliant, and is
+# recommended for auditing use cases. (string value)
+# Allowed values: basic, cadf
+#notification_format = cadf
+
+# You can reduce the number of notifications keystone emits by explicitly
+# opting out. Keystone will not emit notifications that match the patterns
+# expressed in this list. Values are expected to be in the form of
+# `identity.<resource_type>.<operation>`. By default, all notifications related
+# to authentication are automatically suppressed. This field can be set
+# multiple times in order to opt-out of multiple notification topics. For
+# example, the following suppresses notifications describing user creation or
+# successful authentication events: notification_opt_out=identity.user.create
+# notification_opt_out=identity.authenticate.success (multi valued)
+#notification_opt_out = identity.authenticate.success
+#notification_opt_out = identity.authenticate.pending
+#notification_opt_out = identity.authenticate.failed
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of the default
+# INFO level. (boolean value)
+# Note: This option can be changed without restarting.
+#debug = false
+
+# DEPRECATED: If set to false, the logging level will be set to WARNING instead
+# of the default INFO level. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#verbose = true
+
+# The name of a logging configuration file. This file is appended to any
+# existing logging configuration files. For details about logging configuration
+# files, see the Python logging module documentation. Note that when logging
+# configuration files are used then all logging configuration is set in the
+# configuration file and other logging configuration options are ignored (for
+# example, logging_context_format_string). (string value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set. (string
+# value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default is set,
+# logging will go to stderr as defined by use_stderr. This option is ignored if
+# log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths. This option
+# is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is moved or
+# removed this handler will open a new log file with specified path
+# instantaneously. It makes sense only if log_file option is specified and
+# Linux platform is used. This option is ignored if log_config_append is set.
+# (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and will be
+# changed later to honor RFC5424. This option is ignored if log_config_append
+# is set. (boolean value)
+#use_syslog = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Log output to standard error. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_stderr = false
+
+# Format string to use for log messages with context. (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined. (string
+# value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the message
+# is DEBUG. (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. (string value)
+#logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is ignored
+# if log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,dogpile.core.dogpile=INFO
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message. (string
+# value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message. (string
+# value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Interval, number of seconds, of log rate limiting. (integer value)
+#rate_limit_interval = 0
+
+# Maximum number of logged messages per rate_limit_interval. (integer value)
+#rate_limit_burst = 0
+
+# Log level name used by rate limiting: CRITICAL, ERROR, INFO, WARNING, DEBUG
+# or empty string. Logs with level greater or equal to rate_limit_except_level
+# are not filtered. An empty string means that all levels are filtered. (string
+# value)
+#rate_limit_except_level = CRITICAL
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false
+
+#
+# From oslo.messaging
+#
+
+# Size of RPC connection pool. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_conn_pool_size
+#rpc_conn_pool_size = 30
+
+# The pool size limit for connections expiration policy (integer value)
+#conn_pool_min_size = 2
+
+# The time-to-live in sec of idle connections in the pool (integer value)
+#conn_pool_ttl = 1200
+
+# ZeroMQ bind address. Should be a wildcard (*), an ethernet interface, or IP.
+# The "host" option should point or resolve to this address. (string value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_bind_address
+#rpc_zmq_bind_address = *
+
+# MatchMaker driver. (string value)
+# Allowed values: redis, sentinel, dummy
+# Deprecated group/name - [DEFAULT]/rpc_zmq_matchmaker
+#rpc_zmq_matchmaker = redis
+
+# Number of ZeroMQ contexts, defaults to 1. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_contexts
+#rpc_zmq_contexts = 1
+
+# Maximum number of ingress messages to locally buffer per topic. Default is
+# unlimited. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_topic_backlog
+#rpc_zmq_topic_backlog = <None>
+
+# Directory for holding IPC sockets. (string value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_ipc_dir
+#rpc_zmq_ipc_dir = /var/run/openstack
+
+# Name of this node. Must be a valid hostname, FQDN, or IP address. Must match
+# "host" option, if running Nova. (string value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_host
+#rpc_zmq_host = localhost
+
+# Number of seconds to wait before all pending messages will be sent after
+# closing a socket. The default value of -1 specifies an infinite linger
+# period. The value of 0 specifies no linger period. Pending messages shall be
+# discarded immediately when the socket is closed. Positive values specify an
+# upper bound for the linger period. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_cast_timeout
+#zmq_linger = -1
+
+# The default number of seconds that poll should wait. Poll raises timeout
+# exception when timeout expired. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_poll_timeout
+#rpc_poll_timeout = 1
+
+# Expiration timeout in seconds of a name service record about existing target
+# ( < 0 means no timeout). (integer value)
+# Deprecated group/name - [DEFAULT]/zmq_target_expire
+#zmq_target_expire = 300
+
+# Update period in seconds of a name service record about existing target.
+# (integer value)
+# Deprecated group/name - [DEFAULT]/zmq_target_update
+#zmq_target_update = 180
+
+# Use PUB/SUB pattern for fanout methods. PUB/SUB always uses proxy. (boolean
+# value)
+# Deprecated group/name - [DEFAULT]/use_pub_sub
+#use_pub_sub = false
+
+# Use ROUTER remote proxy. (boolean value)
+# Deprecated group/name - [DEFAULT]/use_router_proxy
+#use_router_proxy = false
+
+# This option makes direct connections dynamic or static. It makes sense only
+# with use_router_proxy=False which means to use direct connections for direct
+# message types (ignored otherwise). (boolean value)
+#use_dynamic_connections = false
+
+# How many additional connections to a host will be made for failover reasons.
+# This option is actual only in dynamic connections mode. (integer value)
+#zmq_failover_connections = 2
+
+# Minimal port number for random ports range. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+# Deprecated group/name - [DEFAULT]/rpc_zmq_min_port
+#rpc_zmq_min_port = 49153
+
+# Maximal port number for random ports range. (integer value)
+# Minimum value: 1
+# Maximum value: 65536
+# Deprecated group/name - [DEFAULT]/rpc_zmq_max_port
+#rpc_zmq_max_port = 65536
+
+# Number of retries to find free port number before fail with ZMQBindError.
+# (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_bind_port_retries
+#rpc_zmq_bind_port_retries = 100
+
+# Default serialization mechanism for serializing/deserializing
+# outgoing/incoming messages (string value)
+# Allowed values: json, msgpack
+# Deprecated group/name - [DEFAULT]/rpc_zmq_serialization
+#rpc_zmq_serialization = json
+
+# This option configures round-robin mode in zmq socket. True means not keeping
+# a queue when server side disconnects. False means to keep queue and messages
+# even if server is disconnected, when the server appears we send all
+# accumulated messages to it. (boolean value)
+#zmq_immediate = true
+
+# Enable/disable TCP keepalive (KA) mechanism. The default value of -1 (or any
+# other negative value) means to skip any overrides and leave it to OS default;
+# 0 and 1 (or any other positive value) mean to disable and enable the option
+# respectively. (integer value)
+#zmq_tcp_keepalive = -1
+
+# The duration between two keepalive transmissions in idle condition. The unit
+# is platform dependent, for example, seconds in Linux, milliseconds in Windows
+# etc. The default value of -1 (or any other negative value and 0) means to
+# skip any overrides and leave it to OS default. (integer value)
+#zmq_tcp_keepalive_idle = -1
+
+# The number of retransmissions to be carried out before declaring that remote
+# end is not available. The default value of -1 (or any other negative value
+# and 0) means to skip any overrides and leave it to OS default. (integer
+# value)
+#zmq_tcp_keepalive_cnt = -1
+
+# The duration between two successive keepalive retransmissions, if
+# acknowledgement to the previous keepalive transmission is not received. The
+# unit is platform dependent, for example, seconds in Linux, milliseconds in
+# Windows etc. The default value of -1 (or any other negative value and 0)
+# means to skip any overrides and leave it to OS default. (integer value)
+#zmq_tcp_keepalive_intvl = -1
+
+# Maximum number of (green) threads to work concurrently. (integer value)
+#rpc_thread_pool_size = 100
+
+# Expiration timeout in seconds of a sent/received message after which it is
+# not tracked anymore by a client/server. (integer value)
+#rpc_message_ttl = 300
+
+# Wait for message acknowledgements from receivers. This mechanism works only
+# via proxy without PUB/SUB. (boolean value)
+#rpc_use_acks = false
+
+# Number of seconds to wait for an ack from a cast/call. After each retry
+# attempt this timeout is multiplied by some specified multiplier. (integer
+# value)
+#rpc_ack_timeout_base = 15
+
+# Number to multiply base ack timeout by after each retry attempt. (integer
+# value)
+#rpc_ack_timeout_multiplier = 2
+
+# Default number of message sending attempts in case of any problems occurred:
+# positive value N means at most N retries, 0 means no retries, None or -1 (or
+# any other negative values) mean to retry forever. This option is used only if
+# acknowledgments are enabled. (integer value)
+#rpc_retry_attempts = 3
+
+# List of publisher hosts SubConsumer can subscribe on. This option has higher
+# priority then the default publishers list taken from the matchmaker. (list
+# value)
+#subscribe_on =
+
+# Size of executor thread pool. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_thread_pool_size
+#executor_thread_pool_size = 64
+
+# Seconds to wait for a response from a call. (integer value)
+#rpc_response_timeout = 60
+
+# A URL representing the messaging driver to use and its full configuration.
+# (string value)
+#transport_url = <None>
+
+# DEPRECATED: The messaging driver to use, defaults to rabbit. Other drivers
+# include amqp and zmq. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#rpc_backend = rabbit
+
+# The default exchange under which topics are scoped. May be overridden by an
+# exchange name specified in the transport_url option. (string value)
+#control_exchange = keystone
+
+
+[assignment]
+
+#
+# From keystone
+#
+
+# Entry point for the assignment backend driver (where role assignments are
+# stored) in the `keystone.assignment` namespace. Only a SQL driver is supplied
+# by keystone itself. Unless you are writing proprietary drivers for keystone,
+# you do not need to set this option. (string value)
+#driver = sql
+
+# A list of role names which are prohibited from being an implied role. (list
+# value)
+#prohibited_implied_role = admin
+
+
+[auth]
+
+#
+# From keystone
+#
+
+# Allowed authentication methods. Note: You should disable the `external` auth
+# method if you are currently using federation. External auth and federation
+# both use the REMOTE_USER variable. Since both the mapped and external plugin
+# are being invoked to validate attributes in the request environment, it can
+# cause conflicts. (list value)
+#methods = external,password,token,oauth1,mapped
+
+# Entry point for the password auth plugin module in the
+# `keystone.auth.password` namespace. You do not need to set this unless you
+# are overriding keystone's own password authentication plugin. (string value)
+#password = <None>
+
+# Entry point for the token auth plugin module in the `keystone.auth.token`
+# namespace. You do not need to set this unless you are overriding keystone's
+# own token authentication plugin. (string value)
+#token = <None>
+
+# Entry point for the external (`REMOTE_USER`) auth plugin module in the
+# `keystone.auth.external` namespace. Supplied drivers are `DefaultDomain` and
+# `Domain`. The default driver is `DefaultDomain`, which assumes that all users
+# identified by the username specified to keystone in the `REMOTE_USER`
+# variable exist within the context of the default domain. The `Domain` option
+# expects an additional environment variable be presented to keystone,
+# `REMOTE_DOMAIN`, containing the domain name of the `REMOTE_USER` (if
+# `REMOTE_DOMAIN` is not set, then the default domain will be used instead).
+# You do not need to set this unless you are taking advantage of "external
+# authentication", where the application server (such as Apache) is handling
+# authentication instead of keystone. (string value)
+#external = <None>
+
+# Entry point for the OAuth 1.0a auth plugin module in the
+# `keystone.auth.oauth1` namespace. You do not need to set this unless you are
+# overriding keystone's own `oauth1` authentication plugin. (string value)
+#oauth1 = <None>
+
+# Entry point for the mapped auth plugin module in the `keystone.auth.mapped`
+# namespace. You do not need to set this unless you are overriding keystone's
+# own `mapped` authentication plugin. (string value)
+#mapped = <None>
+
+
+[cache]
+
+#
+# From oslo.cache
+#
+
+# Prefix for building the configuration dictionary for the cache region. This
+# should not need to be changed unless there is another dogpile.cache region
+# with the same configuration name. (string value)
+#config_prefix = cache.oslo
+
+# Default TTL, in seconds, for any cached item in the dogpile.cache region.
+# This applies to any cached method that doesn't have an explicit cache
+# expiration time defined for it. (integer value)
+#expiration_time = 600
+
+# Dogpile.cache backend module. It is recommended that Memcache or Redis
+# (dogpile.cache.redis) be used in production deployments. For eventlet-based
+# or highly threaded servers, Memcache with pooling (oslo_cache.memcache_pool)
+# is recommended. For low thread servers, dogpile.cache.memcached is
+# recommended. Test environments with a single instance of the server can use
+# the dogpile.cache.memory backend. (string value)
+#backend = dogpile.cache.null
+
+# Arguments supplied to the backend module. Specify this option once per
+# argument to be passed to the dogpile.cache backend. Example format:
+# "<argname>:<value>". (multi valued)
+#backend_argument =
+
+# Proxy classes to import that will affect the way the dogpile.cache backend
+# functions. See the dogpile.cache documentation on changing-backend-behavior.
+# (list value)
+#proxies =
+
+# Global toggle for caching. (boolean value)
+#enabled = true
+
+# Extra debugging from the cache backend (cache keys, get/set/delete/etc
+# calls). This is only really useful if you need to see the specific cache-
+# backend get/set/delete calls with the keys/values.  Typically this should be
+# left set to false. (boolean value)
+#debug_cache_backend = false
+
+# Memcache servers in the format of "host:port". (dogpile.cache.memcache and
+# oslo_cache.memcache_pool backends only). (list value)
+#memcache_servers = localhost:11211
+
+# Number of seconds memcached server is considered dead before it is tried
+# again. (dogpile.cache.memcache and oslo_cache.memcache_pool backends only).
+# (integer value)
+#memcache_dead_retry = 300
+
+# Timeout in seconds for every call to a server. (dogpile.cache.memcache and
+# oslo_cache.memcache_pool backends only). (integer value)
+#memcache_socket_timeout = 3
+
+# Max total number of open connections to every memcached server.
+# (oslo_cache.memcache_pool backend only). (integer value)
+#memcache_pool_maxsize = 10
+
+# Number of seconds a connection to memcached is held unused in the pool before
+# it is closed. (oslo_cache.memcache_pool backend only). (integer value)
+#memcache_pool_unused_timeout = 60
+
+# Number of seconds that an operation will wait to get a memcache client
+# connection. (integer value)
+#memcache_pool_connection_get_timeout = 10
+
+
+[catalog]
+
+#
+# From keystone
+#
+
+# Absolute path to the file used for the templated catalog backend. This option
+# is only used if the `[catalog] driver` is set to `templated`. (string value)
+#template_file = default_catalog.templates
+
+# Entry point for the catalog driver in the `keystone.catalog` namespace.
+# Keystone provides a `sql` option (which supports basic CRUD operations
+# through SQL), a `templated` option (which loads the catalog from a templated
+# catalog file on disk), and a `endpoint_filter.sql` option (which supports
+# arbitrary service catalogs per project). (string value)
+#driver = sql
+
+# Toggle for catalog caching. This has no effect unless global caching is
+# enabled. In a typical deployment, there is no reason to disable this.
+# (boolean value)
+#caching = true
+
+# Time to cache catalog data (in seconds). This has no effect unless global and
+# catalog caching are both enabled. Catalog data (services, endpoints, etc.)
+# typically does not change frequently, and so a longer duration than the
+# global default may be desirable. (integer value)
+#cache_time = <None>
+
+# Maximum number of entities that will be returned in a catalog collection.
+# There is typically no reason to set this, as it would be unusual for a
+# deployment to have enough services or endpoints to exceed a reasonable limit.
+# (integer value)
+#list_limit = <None>
+
+
+[cors]
+
+#
+# From oslo.middleware
+#
+
+# Indicate whether this resource may be shared with the domain received in the
+# requests "origin" header. Format: "<protocol>://<host>[:<port>]", no trailing
+# slash. Example: https://horizon.example.com (list value)
+#allowed_origin = <None>
+
+# Indicate that the actual request can include user credentials (boolean value)
+#allow_credentials = true
+
+# Indicate which headers are safe to expose to the API. Defaults to HTTP Simple
+# Headers. (list value)
+#expose_headers = X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token
+
+# Maximum cache age of CORS preflight requests. (integer value)
+#max_age = 3600
+
+# Indicate which methods can be used during the actual request. (list value)
+#allow_methods = GET,PUT,POST,DELETE,PATCH
+
+# Indicate which header field names may be used during the actual request.
+# (list value)
+#allow_headers = X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token,X-Project-Id,X-Project-Name,X-Project-Domain-Id,X-Project-Domain-Name,X-Domain-Id,X-Domain-Name
+
+
+[cors.subdomain]
+
+#
+# From oslo.middleware
+#
+
+# Indicate whether this resource may be shared with the domain received in the
+# requests "origin" header. Format: "<protocol>://<host>[:<port>]", no trailing
+# slash. Example: https://horizon.example.com (list value)
+#allowed_origin = <None>
+
+# Indicate that the actual request can include user credentials (boolean value)
+#allow_credentials = true
+
+# Indicate which headers are safe to expose to the API. Defaults to HTTP Simple
+# Headers. (list value)
+#expose_headers = X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token
+
+# Maximum cache age of CORS preflight requests. (integer value)
+#max_age = 3600
+
+# Indicate which methods can be used during the actual request. (list value)
+#allow_methods = GET,PUT,POST,DELETE,PATCH
+
+# Indicate which header field names may be used during the actual request.
+# (list value)
+#allow_headers = X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token,X-Project-Id,X-Project-Name,X-Project-Domain-Id,X-Project-Domain-Name,X-Domain-Id,X-Domain-Name
+
+
+[credential]
+
+#
+# From keystone
+#
+
+# Entry point for the credential backend driver in the `keystone.credential`
+# namespace. Keystone only provides a `sql` driver, so there's no reason to
+# change this unless you are providing a custom entry point. (string value)
+#driver = sql
+
+# Entry point for credential encryption and decryption operations in the
+# `keystone.credential.provider` namespace. Keystone only provides a `fernet`
+# driver, so there's no reason to change this unless you are providing a custom
+# entry point to encrypt and decrypt credentials. (string value)
+#provider = fernet
+
+# Directory containing Fernet keys used to encrypt and decrypt credentials
+# stored in the credential backend. Fernet keys used to encrypt credentials
+# have no relationship to Fernet keys used to encrypt Fernet tokens. Both sets
+# of keys should be managed separately and require different rotation policies.
+# Do not share this repository with the repository used to manage keys for
+# Fernet tokens. (string value)
+#key_repository = /etc/keystone/credential-keys/
+
+
+[database]
+
+#
+# From oslo.db
+#
+
+# DEPRECATED: The file name to use with SQLite. (string value)
+# Deprecated group/name - [DEFAULT]/sqlite_db
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Should use config option connection or slave_connection to connect
+# the database.
+#sqlite_db = oslo.sqlite
+
+# If True, SQLite uses synchronous mode. (boolean value)
+# Deprecated group/name - [DEFAULT]/sqlite_synchronous
+#sqlite_synchronous = true
+
+# The back end to use for the database. (string value)
+# Deprecated group/name - [DEFAULT]/db_backend
+#backend = sqlalchemy
+
+# The SQLAlchemy connection string to use to connect to the database. (string
+# value)
+# Deprecated group/name - [DEFAULT]/sql_connection
+# Deprecated group/name - [DATABASE]/sql_connection
+# Deprecated group/name - [sql]/connection
+#connection = <None>
+connection = mysql+pymysql://keystone:avi123@localhost/keystone
+
+# The SQLAlchemy connection string to use to connect to the slave database.
+# (string value)
+#slave_connection = <None>
+
+# The SQL mode to be used for MySQL sessions. This option, including the
+# default, overrides any server-set SQL mode. To use whatever SQL mode is set
+# by the server configuration, set this to no value. Example: mysql_sql_mode=
+# (string value)
+#mysql_sql_mode = TRADITIONAL
+
+# Timeout before idle SQL connections are reaped. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_idle_timeout
+# Deprecated group/name - [DATABASE]/sql_idle_timeout
+# Deprecated group/name - [sql]/idle_timeout
+#idle_timeout = 3600
+
+# Minimum number of SQL connections to keep open in a pool. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_min_pool_size
+# Deprecated group/name - [DATABASE]/sql_min_pool_size
+#min_pool_size = 1
+
+# Maximum number of SQL connections to keep open in a pool. Setting a value of
+# 0 indicates no limit. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_pool_size
+# Deprecated group/name - [DATABASE]/sql_max_pool_size
+#max_pool_size = 5
+
+# Maximum number of database connection retries during startup. Set to -1 to
+# specify an infinite retry count. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_retries
+# Deprecated group/name - [DATABASE]/sql_max_retries
+#max_retries = 10
+
+# Interval between retries of opening a SQL connection. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_retry_interval
+# Deprecated group/name - [DATABASE]/reconnect_interval
+#retry_interval = 10
+
+# If set, use this value for max_overflow with SQLAlchemy. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_overflow
+# Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
+#max_overflow = 50
+
+# Verbosity of SQL debugging information: 0=None, 100=Everything. (integer
+# value)
+# Minimum value: 0
+# Maximum value: 100
+# Deprecated group/name - [DEFAULT]/sql_connection_debug
+#connection_debug = 0
+
+# Add Python stack traces to SQL as comment strings. (boolean value)
+# Deprecated group/name - [DEFAULT]/sql_connection_trace
+#connection_trace = false
+
+# If set, use this value for pool_timeout with SQLAlchemy. (integer value)
+# Deprecated group/name - [DATABASE]/sqlalchemy_pool_timeout
+#pool_timeout = <None>
+
+# Enable the experimental use of database reconnect on connection lost.
+# (boolean value)
+#use_db_reconnect = false
+
+# Seconds between retries of a database transaction. (integer value)
+#db_retry_interval = 1
+
+# If True, increases the interval between retries of a database operation up to
+# db_max_retry_interval. (boolean value)
+#db_inc_retry_interval = true
+
+# If db_inc_retry_interval is set, the maximum seconds between retries of a
+# database operation. (integer value)
+#db_max_retry_interval = 10
+
+# Maximum retries in case of connection error or deadlock error before error is
+# raised. Set to -1 to specify an infinite retry count. (integer value)
+#db_max_retries = 20
+
+
+[domain_config]
+
+#
+# From keystone
+#
+
+# Entry point for the domain-specific configuration driver in the
+# `keystone.resource.domain_config` namespace. Only a `sql` option is provided
+# by keystone, so there is no reason to set this unless you are providing a
+# custom entry point. (string value)
+#driver = sql
+
+# Toggle for caching of the domain-specific configuration backend. This has no
+# effect unless global caching is enabled. There is normally no reason to
+# disable this. (boolean value)
+#caching = true
+
+# Time-to-live (TTL, in seconds) to cache domain-specific configuration data.
+# This has no effect unless `[domain_config] caching` is enabled. (integer
+# value)
+#cache_time = 300
+
+
+[endpoint_filter]
+
+#
+# From keystone
+#
+
+# Entry point for the endpoint filter driver in the `keystone.endpoint_filter`
+# namespace. Only a `sql` option is provided by keystone, so there is no reason
+# to set this unless you are providing a custom entry point. (string value)
+#driver = sql
+
+# This controls keystone's behavior if the configured endpoint filters do not
+# result in any endpoints for a user + project pair (and therefore a
+# potentially empty service catalog). If set to true, keystone will return the
+# entire service catalog. If set to false, keystone will return an empty
+# service catalog. (boolean value)
+#return_all_endpoints_if_no_filter = true
+
+
+[endpoint_policy]
+
+#
+# From keystone
+#
+
+# Entry point for the endpoint policy driver in the `keystone.endpoint_policy`
+# namespace. Only a `sql` driver is provided by keystone, so there is no reason
+# to set this unless you are providing a custom entry point. (string value)
+#driver = sql
+
+
+[eventlet_server]
+
+#
+# From keystone
+#
+
+# DEPRECATED: The IP address of the network interface for the public service to
+# listen on. (string value)
+# Deprecated group/name - [DEFAULT]/bind_host
+# Deprecated group/name - [DEFAULT]/public_bind_host
+# This option is deprecated for removal since K.
+# Its value may be silently ignored in the future.
+# Reason: Support for running keystone under eventlet has been removed in the
+# Newton release. These options remain for backwards compatibility because they
+# are used for URL substitutions.
+#public_bind_host = 0.0.0.0
+
+# DEPRECATED: The port number for the public service to listen on. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+# Deprecated group/name - [DEFAULT]/public_port
+# This option is deprecated for removal since K.
+# Its value may be silently ignored in the future.
+# Reason: Support for running keystone under eventlet has been removed in the
+# Newton release. These options remain for backwards compatibility because they
+# are used for URL substitutions.
+#public_port = 5000
+
+# DEPRECATED: The IP address of the network interface for the admin service to
+# listen on. (string value)
+# Deprecated group/name - [DEFAULT]/bind_host
+# Deprecated group/name - [DEFAULT]/admin_bind_host
+# This option is deprecated for removal since K.
+# Its value may be silently ignored in the future.
+# Reason: Support for running keystone under eventlet has been removed in the
+# Newton release. These options remain for backwards compatibility because they
+# are used for URL substitutions.
+#admin_bind_host = 0.0.0.0
+
+# DEPRECATED: The port number for the admin service to listen on. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+# Deprecated group/name - [DEFAULT]/admin_port
+# This option is deprecated for removal since K.
+# Its value may be silently ignored in the future.
+# Reason: Support for running keystone under eventlet has been removed in the
+# Newton release. These options remain for backwards compatibility because they
+# are used for URL substitutions.
+#admin_port = 35357
+
+
+[extra_headers]
+
+#
+# From keystone
+#
+
+# Specifies the distribution of the keystone server. (string value)
+#Distribution = Ubuntu
+
+
+[federation]
+
+#
+# From keystone
+#
+
+# Entry point for the federation backend driver in the `keystone.federation`
+# namespace. Keystone only provides a `sql` driver, so there is no reason to
+# set this option unless you are providing a custom entry point. (string value)
+#driver = sql
+
+# Prefix to use when filtering environment variable names for federated
+# assertions. Matched variables are passed into the federated mapping engine.
+# (string value)
+#assertion_prefix =
+
+# Value to be used to obtain the entity ID of the Identity Provider from the
+# environment. For `mod_shib`, this would be `Shib-Identity-Provider`. For For
+# `mod_auth_openidc`, this could be `HTTP_OIDC_ISS`. For `mod_auth_mellon`,
+# this could be `MELLON_IDP`. (string value)
+#remote_id_attribute = <None>
+
+# An arbitrary domain name that is reserved to allow federated ephemeral users
+# to have a domain concept. Note that an admin will not be able to create a
+# domain with this name or update an existing domain to this name. You are not
+# advised to change this value unless you really have to. (string value)
+#federated_domain_name = Federated
+
+# A list of trusted dashboard hosts. Before accepting a Single Sign-On request
+# to return a token, the origin host must be a member of this list. This
+# configuration option may be repeated for multiple values. You must set this
+# in order to use web-based SSO flows. For example:
+# trusted_dashboard=https://acme.example.com/auth/websso
+# trusted_dashboard=https://beta.example.com/auth/websso (multi valued)
+#trusted_dashboard =
+
+# Absolute path to an HTML file used as a Single Sign-On callback handler. This
+# page is expected to redirect the user from keystone back to a trusted
+# dashboard host, by form encoding a token in a POST request. Keystone's
+# default value should be sufficient for most deployments. (string value)
+#sso_callback_template = /etc/keystone/sso_callback_template.html
+
+# Toggle for federation caching. This has no effect unless global caching is
+# enabled. There is typically no reason to disable this. (boolean value)
+#caching = true
+
+
+[fernet_tokens]
+
+#
+# From keystone
+#
+
+# Directory containing Fernet token keys. This directory must exist before
+# using `keystone-manage fernet_setup` for the first time, must be writable by
+# the user running `keystone-manage fernet_setup` or `keystone-manage
+# fernet_rotate`, and of course must be readable by keystone's server process.
+# The repository may contain keys in one of three states: a single staged key
+# (always index 0) used for token validation, a single primary key (always the
+# highest index) used for token creation and validation, and any number of
+# secondary keys (all other index values) used for token validation. With
+# multiple keystone nodes, each node must share the same key repository
+# contents, with the exception of the staged key (index 0). It is safe to run
+# `keystone-manage fernet_rotate` once on any one node to promote a staged key
+# (index 0) to be the new primary (incremented from the previous highest
+# index), and produce a new staged key (a new key with index 0); the resulting
+# repository can then be atomically replicated to other nodes without any risk
+# of race conditions (for example, it is safe to run `keystone-manage
+# fernet_rotate` on host A, wait any amount of time, create a tarball of the
+# directory on host A, unpack it on host B to a temporary location, and
+# atomically move (`mv`) the directory into place on host B). Running
+# `keystone-manage fernet_rotate` *twice* on a key repository without syncing
+# other nodes will result in tokens that can not be validated by all nodes.
+# (string value)
+#key_repository = /etc/keystone/fernet-keys/
+
+# This controls how many keys are held in rotation by `keystone-manage
+# fernet_rotate` before they are discarded. The default value of 3 means that
+# keystone will maintain one staged key (always index 0), one primary key (the
+# highest numerical index), and one secondary key (every other index).
+# Increasing this value means that additional secondary keys will be kept in
+# the rotation. (integer value)
+# Minimum value: 1
+#max_active_keys = 3
+
+
+[healthcheck]
+
+#
+# From oslo.middleware
+#
+
+# DEPRECATED: The path to respond to healtcheck requests on. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#path = /healthcheck
+
+# Show more detailed information as part of the response (boolean value)
+#detailed = false
+
+# Additional backends that can perform health checks and report that
+# information back as part of a request. (list value)
+#backends =
+
+# Check the presence of a file to determine if an application is running on a
+# port. Used by DisableByFileHealthcheck plugin. (string value)
+#disable_by_file_path = <None>
+
+# Check the presence of a file based on a port to determine if an application
+# is running on a port. Expects a "port:path" list of strings. Used by
+# DisableByFilesPortsHealthcheck plugin. (list value)
+#disable_by_file_paths =
+
+
+[identity]
+
+#
+# From keystone
+#
+
+# This references the domain to use for all Identity API v2 requests (which are
+# not aware of domains). A domain with this ID can optionally be created for
+# you by `keystone-manage bootstrap`. The domain referenced by this ID cannot
+# be deleted on the v3 API, to prevent accidentally breaking the v2 API. There
+# is nothing special about this domain, other than the fact that it must exist
+# to order to maintain support for your v2 clients. There is typically no
+# reason to change this value. (string value)
+#default_domain_id = default
+
+# A subset (or all) of domains can have their own identity driver, each with
+# their own partial configuration options, stored in either the resource
+# backend or in a file in a domain configuration directory (depending on the
+# setting of `[identity] domain_configurations_from_database`). Only values
+# specific to the domain need to be specified in this manner. This feature is
+# disabled by default, but may be enabled by default in a future release; set
+# to true to enable. (boolean value)
+#domain_specific_drivers_enabled = false
+
+# By default, domain-specific configuration data is read from files in the
+# directory identified by `[identity] domain_config_dir`. Enabling this
+# configuration option allows you to instead manage domain-specific
+# configurations through the API, which are then persisted in the backend
+# (typically, a SQL database), rather than using configuration files on disk.
+# (boolean value)
+#domain_configurations_from_database = false
+
+# Absolute path where keystone should locate domain-specific `[identity]`
+# configuration files. This option has no effect unless `[identity]
+# domain_specific_drivers_enabled` is set to true. There is typically no reason
+# to change this value. (string value)
+#domain_config_dir = /etc/keystone/domains
+
+# Entry point for the identity backend driver in the `keystone.identity`
+# namespace. Keystone provides a `sql` and `ldap` driver. This option is also
+# used as the default driver selection (along with the other configuration
+# variables in this section) in the event that `[identity]
+# domain_specific_drivers_enabled` is enabled, but no applicable domain-
+# specific configuration is defined for the domain in question. Unless your
+# deployment primarily relies on `ldap` AND is not using domain-specific
+# configuration, you should typically leave this set to `sql`. (string value)
+#driver = sql
+
+# Toggle for identity caching. This has no effect unless global caching is
+# enabled. There is typically no reason to disable this. (boolean value)
+#caching = true
+
+# Time to cache identity data (in seconds). This has no effect unless global
+# and identity caching are enabled. (integer value)
+#cache_time = 600
+
+# Maximum allowed length for user passwords. Decrease this value to improve
+# performance. Changing this value does not effect existing passwords. (integer
+# value)
+# Maximum value: 4096
+#max_password_length = 4096
+
+# Maximum number of entities that will be returned in an identity collection.
+# (integer value)
+#list_limit = <None>
+
+
+[identity_mapping]
+
+#
+# From keystone
+#
+
+# Entry point for the identity mapping backend driver in the
+# `keystone.identity.id_mapping` namespace. Keystone only provides a `sql`
+# driver, so there is no reason to change this unless you are providing a
+# custom entry point. (string value)
+#driver = sql
+
+# Entry point for the public ID generator for user and group entities in the
+# `keystone.identity.id_generator` namespace. The Keystone identity mapper only
+# supports generators that produce 64 bytes or less. Keystone only provides a
+# `sha256` entry point, so there is no reason to change this value unless
+# you're providing a custom entry point. (string value)
+#generator = sha256
+
+# The format of user and group IDs changed in Juno for backends that do not
+# generate UUIDs (for example, LDAP), with keystone providing a hash mapping to
+# the underlying attribute in LDAP. By default this mapping is disabled, which
+# ensures that existing IDs will not change. Even when the mapping is enabled
+# by using domain-specific drivers (`[identity]
+# domain_specific_drivers_enabled`), any users and groups from the default
+# domain being handled by LDAP will still not be mapped to ensure their IDs
+# remain backward compatible. Setting this value to false will enable the new
+# mapping for all backends, including the default LDAP driver. It is only
+# guaranteed to be safe to enable this option if you do not already have
+# assignments for users and groups from the default LDAP domain, and you
+# consider it to be acceptable for Keystone to provide the different IDs to
+# clients than it did previously (existing IDs in the API will suddenly
+# change). Typically this means that the only time you can set this value to
+# false is when configuring a fresh installation, although that is the
+# recommended value. (boolean value)
+#backward_compatible_ids = true
+
+
+[kvs]
+
+#
+# From keystone
+#
+
+# DEPRECATED: Extra `dogpile.cache` backend modules to register with the
+# `dogpile.cache` library. It is not necessary to set this value unless you are
+# providing a custom KVS backend beyond what `dogpile.cache` already supports.
+# (list value)
+# This option is deprecated for removal since O.
+# Its value may be silently ignored in the future.
+# Reason: This option has been deprecated in the O release and will be removed
+# in the P release. Use SQL backends instead.
+#backends =
+
+# DEPRECATED: Prefix for building the configuration dictionary for the KVS
+# region. This should not need to be changed unless there is another
+# `dogpile.cache` region with the same configuration name. (string value)
+# This option is deprecated for removal since O.
+# Its value may be silently ignored in the future.
+# Reason: This option has been deprecated in the O release and will be removed
+# in the P release. Use SQL backends instead.
+#config_prefix = keystone.kvs
+
+# DEPRECATED: Set to false to disable using a key-mangling function, which
+# ensures fixed-length keys are used in the KVS store. This is configurable for
+# debugging purposes, and it is therefore highly recommended to always leave
+# this set to true. (boolean value)
+# This option is deprecated for removal since O.
+# Its value may be silently ignored in the future.
+# Reason: This option has been deprecated in the O release and will be removed
+# in the P release. Use SQL backends instead.
+#enable_key_mangler = true
+
+# DEPRECATED: Number of seconds after acquiring a distributed lock that the
+# backend should consider the lock to be expired. This option should be tuned
+# relative to the longest amount of time that it takes to perform a successful
+# operation. If this value is set too low, then a cluster will end up
+# performing work redundantly. If this value is set too high, then a cluster
+# will not be able to efficiently recover and retry after a failed operation. A
+# non-zero value is recommended if the backend supports lock timeouts, as zero
+# prevents locks from expiring altogether. (integer value)
+# Minimum value: 0
+# This option is deprecated for removal since O.
+# Its value may be silently ignored in the future.
+# Reason: This option has been deprecated in the O release and will be removed
+# in the P release. Use SQL backends instead.
+#default_lock_timeout = 5
+
+
+[ldap]
+
+#
+# From keystone
+#
+
+# URL(s) for connecting to the LDAP server. Multiple LDAP URLs may be specified
+# as a comma separated string. The first URL to successfully bind is used for
+# the connection. (string value)
+#url = ldap://localhost
+
+# The user name of the administrator bind DN to use when querying the LDAP
+# server, if your LDAP server requires it. (string value)
+#user = <None>
+
+# The password of the administrator bind DN to use when querying the LDAP
+# server, if your LDAP server requires it. (string value)
+#password = <None>
+
+# The default LDAP server suffix to use, if a DN is not defined via either
+# `[ldap] user_tree_dn` or `[ldap] group_tree_dn`. (string value)
+#suffix = cn=example,cn=com
+
+# The search scope which defines how deep to search within the search base. A
+# value of `one` (representing `oneLevel` or `singleLevel`) indicates a search
+# of objects immediately below to the base object, but does not include the
+# base object itself. A value of `sub` (representing `subtree` or
+# `wholeSubtree`) indicates a search of both the base object itself and the
+# entire subtree below it. (string value)
+# Allowed values: one, sub
+#query_scope = one
+
+# Defines the maximum number of results per page that keystone should request
+# from the LDAP server when listing objects. A value of zero (`0`) disables
+# paging. (integer value)
+# Minimum value: 0
+#page_size = 0
+
+# The LDAP dereferencing option to use for queries involving aliases. A value
+# of `default` falls back to using default dereferencing behavior configured by
+# your `ldap.conf`. A value of `never` prevents aliases from being dereferenced
+# at all. A value of `searching` dereferences aliases only after name
+# resolution. A value of `finding` dereferences aliases only during name
+# resolution. A value of `always` dereferences aliases in all cases. (string
+# value)
+# Allowed values: never, searching, always, finding, default
+#alias_dereferencing = default
+
+# Sets the LDAP debugging level for LDAP calls. A value of 0 means that
+# debugging is not enabled. This value is a bitmask, consult your LDAP
+# documentation for possible values. (integer value)
+# Minimum value: -1
+#debug_level = <None>
+
+# Sets keystone's referral chasing behavior across directory partitions. If
+# left unset, the system's default behavior will be used. (boolean value)
+#chase_referrals = <None>
+
+# The search base to use for users. Defaults to the `[ldap] suffix` value.
+# (string value)
+#user_tree_dn = <None>
+
+# The LDAP search filter to use for users. (string value)
+#user_filter = <None>
+
+# The LDAP object class to use for users. (string value)
+#user_objectclass = inetOrgPerson
+
+# The LDAP attribute mapped to user IDs in keystone. This must NOT be a
+# multivalued attribute. User IDs are expected to be globally unique across
+# keystone domains and URL-safe. (string value)
+#user_id_attribute = cn
+
+# The LDAP attribute mapped to user names in keystone. User names are expected
+# to be unique only within a keystone domain and are not expected to be URL-
+# safe. (string value)
+#user_name_attribute = sn
+
+# The LDAP attribute mapped to user descriptions in keystone. (string value)
+#user_description_attribute = description
+
+# The LDAP attribute mapped to user emails in keystone. (string value)
+#user_mail_attribute = mail
+
+# The LDAP attribute mapped to user passwords in keystone. (string value)
+#user_pass_attribute = userPassword
+
+# The LDAP attribute mapped to the user enabled attribute in keystone. If
+# setting this option to `userAccountControl`, then you may be interested in
+# setting `[ldap] user_enabled_mask` and `[ldap] user_enabled_default` as well.
+# (string value)
+#user_enabled_attribute = enabled
+
+# Logically negate the boolean value of the enabled attribute obtained from the
+# LDAP server. Some LDAP servers use a boolean lock attribute where "true"
+# means an account is disabled. Setting `[ldap] user_enabled_invert = true`
+# will allow these lock attributes to be used. This option will have no effect
+# if either the `[ldap] user_enabled_mask` or `[ldap] user_enabled_emulation`
+# options are in use. (boolean value)
+#user_enabled_invert = false
+
+# Bitmask integer to select which bit indicates the enabled value if the LDAP
+# server represents "enabled" as a bit on an integer rather than as a discrete
+# boolean. A value of `0` indicates that the mask is not used. If this is not
+# set to `0` the typical value is `2`. This is typically used when `[ldap]
+# user_enabled_attribute = userAccountControl`. Setting this option causes
+# keystone to ignore the value of `[ldap] user_enabled_invert`. (integer value)
+# Minimum value: 0
+#user_enabled_mask = 0
+
+# The default value to enable users. This should match an appropriate integer
+# value if the LDAP server uses non-boolean (bitmask) values to indicate if a
+# user is enabled or disabled. If this is not set to `True`, then the typical
+# value is `512`. This is typically used when `[ldap] user_enabled_attribute =
+# userAccountControl`. (string value)
+#user_enabled_default = True
+
+# List of user attributes to ignore on create and update, or whether a specific
+# user attribute should be filtered for list or show user. (list value)
+#user_attribute_ignore = default_project_id
+
+# The LDAP attribute mapped to a user's default_project_id in keystone. This is
+# most commonly used when keystone has write access to LDAP. (string value)
+#user_default_project_id_attribute = <None>
+
+# If enabled, keystone uses an alternative method to determine if a user is
+# enabled or not by checking if they are a member of the group defined by the
+# `[ldap] user_enabled_emulation_dn` option. Enabling this option causes
+# keystone to ignore the value of `[ldap] user_enabled_invert`. (boolean value)
+#user_enabled_emulation = false
+
+# DN of the group entry to hold enabled users when using enabled emulation.
+# Setting this option has no effect unless `[ldap] user_enabled_emulation` is
+# also enabled. (string value)
+#user_enabled_emulation_dn = <None>
+
+# Use the `[ldap] group_member_attribute` and `[ldap] group_objectclass`
+# settings to determine membership in the emulated enabled group. Enabling this
+# option has no effect unless `[ldap] user_enabled_emulation` is also enabled.
+# (boolean value)
+#user_enabled_emulation_use_group_config = false
+
+# A list of LDAP attribute to keystone user attribute pairs used for mapping
+# additional attributes to users in keystone. The expected format is
+# `<ldap_attr>:<user_attr>`, where `ldap_attr` is the attribute in the LDAP
+# object and `user_attr` is the attribute which should appear in the identity
+# API. (list value)
+#user_additional_attribute_mapping =
+
+# The search base to use for groups. Defaults to the `[ldap] suffix` value.
+# (string value)
+#group_tree_dn = <None>
+
+# The LDAP search filter to use for groups. (string value)
+#group_filter = <None>
+
+# The LDAP object class to use for groups. If setting this option to
+# `posixGroup`, you may also be interested in enabling the `[ldap]
+# group_members_are_ids` option. (string value)
+#group_objectclass = groupOfNames
+
+# The LDAP attribute mapped to group IDs in keystone. This must NOT be a
+# multivalued attribute. Group IDs are expected to be globally unique across
+# keystone domains and URL-safe. (string value)
+#group_id_attribute = cn
+
+# The LDAP attribute mapped to group names in keystone. Group names are
+# expected to be unique only within a keystone domain and are not expected to
+# be URL-safe. (string value)
+#group_name_attribute = ou
+
+# The LDAP attribute used to indicate that a user is a member of the group.
+# (string value)
+#group_member_attribute = member
+
+# Enable this option if the members of the group object class are keystone user
+# IDs rather than LDAP DNs. This is the case when using `posixGroup` as the
+# group object class in Open Directory. (boolean value)
+#group_members_are_ids = false
+
+# The LDAP attribute mapped to group descriptions in keystone. (string value)
+#group_desc_attribute = description
+
+# List of group attributes to ignore on create and update. or whether a
+# specific group attribute should be filtered for list or show group. (list
+# value)
+#group_attribute_ignore =
+
+# A list of LDAP attribute to keystone group attribute pairs used for mapping
+# additional attributes to groups in keystone. The expected format is
+# `<ldap_attr>:<group_attr>`, where `ldap_attr` is the attribute in the LDAP
+# object and `group_attr` is the attribute which should appear in the identity
+# API. (list value)
+#group_additional_attribute_mapping =
+
+# If enabled, group queries will use Active Directory specific filters for
+# nested groups. (boolean value)
+#group_ad_nesting = false
+
+# An absolute path to a CA certificate file to use when communicating with LDAP
+# servers. This option will take precedence over `[ldap] tls_cacertdir`, so
+# there is no reason to set both. (string value)
+#tls_cacertfile = <None>
+
+# An absolute path to a CA certificate directory to use when communicating with
+# LDAP servers. There is no reason to set this option if you've also set
+# `[ldap] tls_cacertfile`. (string value)
+#tls_cacertdir = <None>
+
+# Enable TLS when communicating with LDAP servers. You should also set the
+# `[ldap] tls_cacertfile` and `[ldap] tls_cacertdir` options when using this
+# option. Do not set this option if you are using LDAP over SSL (LDAPS) instead
+# of TLS. (boolean value)
+#use_tls = false
+
+# Specifies which checks to perform against client certificates on incoming TLS
+# sessions. If set to `demand`, then a certificate will always be requested and
+# required from the LDAP server. If set to `allow`, then a certificate will
+# always be requested but not required from the LDAP server. If set to `never`,
+# then a certificate will never be requested. (string value)
+# Allowed values: demand, never, allow
+#tls_req_cert = demand
+
+# The connection timeout to use with the LDAP server. A value of `-1` means
+# that connections will never timeout. (integer value)
+# Minimum value: -1
+#connection_timeout = -1
+
+# Enable LDAP connection pooling for queries to the LDAP server. There is
+# typically no reason to disable this. (boolean value)
+#use_pool = true
+
+# The size of the LDAP connection pool. This option has no effect unless
+# `[ldap] use_pool` is also enabled. (integer value)
+# Minimum value: 1
+#pool_size = 10
+
+# The maximum number of times to attempt reconnecting to the LDAP server before
+# aborting. A value of zero prevents retries. This option has no effect unless
+# `[ldap] use_pool` is also enabled. (integer value)
+# Minimum value: 0
+#pool_retry_max = 3
+
+# The number of seconds to wait before attempting to reconnect to the LDAP
+# server. This option has no effect unless `[ldap] use_pool` is also enabled.
+# (floating point value)
+#pool_retry_delay = 0.1
+
+# The connection timeout to use when pooling LDAP connections. A value of `-1`
+# means that connections will never timeout. This option has no effect unless
+# `[ldap] use_pool` is also enabled. (integer value)
+# Minimum value: -1
+#pool_connection_timeout = -1
+
+# The maximum connection lifetime to the LDAP server in seconds. When this
+# lifetime is exceeded, the connection will be unbound and removed from the
+# connection pool. This option has no effect unless `[ldap] use_pool` is also
+# enabled. (integer value)
+# Minimum value: 1
+#pool_connection_lifetime = 600
+
+# Enable LDAP connection pooling for end user authentication. There is
+# typically no reason to disable this. (boolean value)
+#use_auth_pool = true
+
+# The size of the connection pool to use for end user authentication. This
+# option has no effect unless `[ldap] use_auth_pool` is also enabled. (integer
+# value)
+# Minimum value: 1
+#auth_pool_size = 100
+
+# The maximum end user authentication connection lifetime to the LDAP server in
+# seconds. When this lifetime is exceeded, the connection will be unbound and
+# removed from the connection pool. This option has no effect unless `[ldap]
+# use_auth_pool` is also enabled. (integer value)
+# Minimum value: 1
+#auth_pool_connection_lifetime = 60
+
+
+[matchmaker_redis]
+
+#
+# From oslo.messaging
+#
+
+# DEPRECATED: Host to locate redis. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#host = 127.0.0.1
+
+# DEPRECATED: Use this port to connect to redis host. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#port = 6379
+
+# DEPRECATED: Password for Redis server (optional). (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#password =
+
+# DEPRECATED: List of Redis Sentinel hosts (fault tolerance mode), e.g.,
+# [host:port, host1:port ... ] (list value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#sentinel_hosts =
+
+# Redis replica set name. (string value)
+#sentinel_group_name = oslo-messaging-zeromq
+
+# Time in ms to wait between connection attempts. (integer value)
+#wait_timeout = 2000
+
+# Time in ms to wait before the transaction is killed. (integer value)
+#check_timeout = 20000
+
+# Timeout in ms on blocking socket operations. (integer value)
+#socket_timeout = 10000
+
+
+[memcache]
+
+#
+# From keystone
+#
+
+# DEPRECATED: Comma-separated list of memcached servers in the format of
+# `host:port,host:port` that keystone should use for the `memcache` token
+# persistence provider and other memcache-backed KVS drivers. This
+# configuration value is NOT used for intermediary caching between keystone and
+# other backends, such as SQL and LDAP (for that, see the `[cache]` section).
+# Multiple keystone servers in the same deployment should use the same set of
+# memcached servers to ensure that data (such as UUID tokens) created by one
+# node is available to the others. (list value)
+# This option is deprecated for removal since O.
+# Its value may be silently ignored in the future.
+# Reason: This option has been deprecated in the O release and will be removed
+# in the P release. Use oslo.cache instead.
+#servers = localhost:11211
+
+# Number of seconds memcached server is considered dead before it is tried
+# again. This is used by the key value store system. (integer value)
+#dead_retry = 300
+
+# Timeout in seconds for every call to a server. This is used by the key value
+# store system. (integer value)
+#socket_timeout = 3
+
+# Max total number of open connections to every memcached server. This is used
+# by the key value store system. (integer value)
+#pool_maxsize = 10
+
+# Number of seconds a connection to memcached is held unused in the pool before
+# it is closed. This is used by the key value store system. (integer value)
+#pool_unused_timeout = 60
+
+# Number of seconds that an operation will wait to get a memcache client
+# connection. This is used by the key value store system. (integer value)
+#pool_connection_get_timeout = 10
+
+
+[oauth1]
+
+#
+# From keystone
+#
+
+# Entry point for the OAuth backend driver in the `keystone.oauth1` namespace.
+# Typically, there is no reason to set this option unless you are providing a
+# custom entry point. (string value)
+#driver = sql
+
+# Number of seconds for the OAuth Request Token to remain valid after being
+# created. This is the amount of time the user has to authorize the token.
+# Setting this option to zero means that request tokens will last forever.
+# (integer value)
+# Minimum value: 0
+#request_token_duration = 28800
+
+# Number of seconds for the OAuth Access Token to remain valid after being
+# created. This is the amount of time the consumer has to interact with the
+# service provider (which is typically keystone). Setting this option to zero
+# means that access tokens will last forever. (integer value)
+# Minimum value: 0
+#access_token_duration = 86400
+
+
+[oslo_messaging_amqp]
+
+#
+# From oslo.messaging
+#
+
+# Name for the AMQP container. must be globally unique. Defaults to a generated
+# UUID (string value)
+# Deprecated group/name - [amqp1]/container_name
+#container_name = <None>
+
+# Timeout for inactive connections (in seconds) (integer value)
+# Deprecated group/name - [amqp1]/idle_timeout
+#idle_timeout = 0
+
+# Debug: dump AMQP frames to stdout (boolean value)
+# Deprecated group/name - [amqp1]/trace
+#trace = false
+
+# CA certificate PEM file used to verify the server's certificate (string
+# value)
+# Deprecated group/name - [amqp1]/ssl_ca_file
+#ssl_ca_file =
+
+# Self-identifying certificate PEM file for client authentication (string
+# value)
+# Deprecated group/name - [amqp1]/ssl_cert_file
+#ssl_cert_file =
+
+# Private key PEM file used to sign ssl_cert_file certificate (optional)
+# (string value)
+# Deprecated group/name - [amqp1]/ssl_key_file
+#ssl_key_file =
+
+# Password for decrypting ssl_key_file (if encrypted) (string value)
+# Deprecated group/name - [amqp1]/ssl_key_password
+#ssl_key_password = <None>
+
+# DEPRECATED: Accept clients using either SSL or plain TCP (boolean value)
+# Deprecated group/name - [amqp1]/allow_insecure_clients
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Not applicable - not a SSL server
+#allow_insecure_clients = false
+
+# Space separated list of acceptable SASL mechanisms (string value)
+# Deprecated group/name - [amqp1]/sasl_mechanisms
+#sasl_mechanisms =
+
+# Path to directory that contains the SASL configuration (string value)
+# Deprecated group/name - [amqp1]/sasl_config_dir
+#sasl_config_dir =
+
+# Name of configuration file (without .conf suffix) (string value)
+# Deprecated group/name - [amqp1]/sasl_config_name
+#sasl_config_name =
+
+# User name for message broker authentication (string value)
+# Deprecated group/name - [amqp1]/username
+#username =
+
+# Password for message broker authentication (string value)
+# Deprecated group/name - [amqp1]/password
+#password =
+
+# Seconds to pause before attempting to re-connect. (integer value)
+# Minimum value: 1
+#connection_retry_interval = 1
+
+# Increase the connection_retry_interval by this many seconds after each
+# unsuccessful failover attempt. (integer value)
+# Minimum value: 0
+#connection_retry_backoff = 2
+
+# Maximum limit for connection_retry_interval + connection_retry_backoff
+# (integer value)
+# Minimum value: 1
+#connection_retry_interval_max = 30
+
+# Time to pause between re-connecting an AMQP 1.0 link that failed due to a
+# recoverable error. (integer value)
+# Minimum value: 1
+#link_retry_delay = 10
+
+# The maximum number of attempts to re-send a reply message which failed due to
+# a recoverable error. (integer value)
+# Minimum value: -1
+#default_reply_retry = 0
+
+# The deadline for an rpc reply message delivery. (integer value)
+# Minimum value: 5
+#default_reply_timeout = 30
+
+# The deadline for an rpc cast or call message delivery. Only used when caller
+# does not provide a timeout expiry. (integer value)
+# Minimum value: 5
+#default_send_timeout = 30
+
+# The deadline for a sent notification message delivery. Only used when caller
+# does not provide a timeout expiry. (integer value)
+# Minimum value: 5
+#default_notify_timeout = 30
+
+# The duration to schedule a purge of idle sender links. Detach link after
+# expiry. (integer value)
+# Minimum value: 1
+#default_sender_link_timeout = 600
+
+# Indicates the addressing mode used by the driver.
+# Permitted values:
+# 'legacy'   - use legacy non-routable addressing
+# 'routable' - use routable addresses
+# 'dynamic'  - use legacy addresses if the message bus does not support routing
+# otherwise use routable addressing (string value)
+#addressing_mode = dynamic
+
+# address prefix used when sending to a specific server (string value)
+# Deprecated group/name - [amqp1]/server_request_prefix
+#server_request_prefix = exclusive
+
+# address prefix used when broadcasting to all servers (string value)
+# Deprecated group/name - [amqp1]/broadcast_prefix
+#broadcast_prefix = broadcast
+
+# address prefix when sending to any server in group (string value)
+# Deprecated group/name - [amqp1]/group_request_prefix
+#group_request_prefix = unicast
+
+# Address prefix for all generated RPC addresses (string value)
+#rpc_address_prefix = openstack.org/om/rpc
+
+# Address prefix for all generated Notification addresses (string value)
+#notify_address_prefix = openstack.org/om/notify
+
+# Appended to the address prefix when sending a fanout message. Used by the
+# message bus to identify fanout messages. (string value)
+#multicast_address = multicast
+
+# Appended to the address prefix when sending to a particular RPC/Notification
+# server. Used by the message bus to identify messages sent to a single
+# destination. (string value)
+#unicast_address = unicast
+
+# Appended to the address prefix when sending to a group of consumers. Used by
+# the message bus to identify messages that should be delivered in a round-
+# robin fashion across consumers. (string value)
+#anycast_address = anycast
+
+# Exchange name used in notification addresses.
+# Exchange name resolution precedence:
+# Target.exchange if set
+# else default_notification_exchange if set
+# else control_exchange if set
+# else 'notify' (string value)
+#default_notification_exchange = <None>
+
+# Exchange name used in RPC addresses.
+# Exchange name resolution precedence:
+# Target.exchange if set
+# else default_rpc_exchange if set
+# else control_exchange if set
+# else 'rpc' (string value)
+#default_rpc_exchange = <None>
+
+# Window size for incoming RPC Reply messages. (integer value)
+# Minimum value: 1
+#reply_link_credit = 200
+
+# Window size for incoming RPC Request messages (integer value)
+# Minimum value: 1
+#rpc_server_credit = 100
+
+# Window size for incoming Notification messages (integer value)
+# Minimum value: 1
+#notify_server_credit = 100
+
+# Send messages of this type pre-settled.
+# Pre-settled messages will not receive acknowledgement
+# from the peer. Note well: pre-settled messages may be
+# silently discarded if the delivery fails.
+# Permitted values:
+# 'rpc-call' - send RPC Calls pre-settled
+# 'rpc-reply'- send RPC Replies pre-settled
+# 'rpc-cast' - Send RPC Casts pre-settled
+# 'notify'   - Send Notifications pre-settled
+#  (multi valued)
+#pre_settled = rpc-cast
+#pre_settled = rpc-reply
+
+
+[oslo_messaging_kafka]
+
+#
+# From oslo.messaging
+#
+
+# DEPRECATED: Default Kafka broker Host (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#kafka_default_host = localhost
+
+# DEPRECATED: Default Kafka broker Port (port value)
+# Minimum value: 0
+# Maximum value: 65535
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#kafka_default_port = 9092
+
+# Max fetch bytes of Kafka consumer (integer value)
+#kafka_max_fetch_bytes = 1048576
+
+# Default timeout(s) for Kafka consumers (integer value)
+#kafka_consumer_timeout = 1.0
+
+# Pool Size for Kafka Consumers (integer value)
+#pool_size = 10
+
+# The pool size limit for connections expiration policy (integer value)
+#conn_pool_min_size = 2
+
+# The time-to-live in sec of idle connections in the pool (integer value)
+#conn_pool_ttl = 1200
+
+# Group id for Kafka consumer. Consumers in one group will coordinate message
+# consumption (string value)
+#consumer_group = oslo_messaging_consumer
+
+# Upper bound on the delay for KafkaProducer batching in seconds (floating
+# point value)
+#producer_batch_timeout = 0.0
+
+# Size of batch for the producer async send (integer value)
+#producer_batch_size = 16384
+
+
+[oslo_messaging_notifications]
+
+#
+# From oslo.messaging
+#
+
+# The Drivers(s) to handle sending notifications. Possible values are
+# messaging, messagingv2, routing, log, test, noop (multi valued)
+# Deprecated group/name - [DEFAULT]/notification_driver
+#driver =
+
+# A URL representing the messaging driver to use for notifications. If not set,
+# we fall back to the same configuration used for RPC. (string value)
+# Deprecated group/name - [DEFAULT]/notification_transport_url
+#transport_url = <None>
+
+# AMQP topic used for OpenStack notifications. (list value)
+# Deprecated group/name - [rpc_notifier2]/topics
+# Deprecated group/name - [DEFAULT]/notification_topics
+#topics = notifications
+
+
+[oslo_messaging_rabbit]
+
+#
+# From oslo.messaging
+#
+
+# Use durable queues in AMQP. (boolean value)
+# Deprecated group/name - [DEFAULT]/amqp_durable_queues
+# Deprecated group/name - [DEFAULT]/rabbit_durable_queues
+#amqp_durable_queues = false
+
+# Auto-delete queues in AMQP. (boolean value)
+# Deprecated group/name - [DEFAULT]/amqp_auto_delete
+#amqp_auto_delete = false
+
+# SSL version to use (valid only if SSL enabled). Valid values are TLSv1 and
+# SSLv23. SSLv2, SSLv3, TLSv1_1, and TLSv1_2 may be available on some
+# distributions. (string value)
+# Deprecated group/name - [DEFAULT]/kombu_ssl_version
+#kombu_ssl_version =
+
+# SSL key file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [DEFAULT]/kombu_ssl_keyfile
+#kombu_ssl_keyfile =
+
+# SSL cert file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [DEFAULT]/kombu_ssl_certfile
+#kombu_ssl_certfile =
+
+# SSL certification authority file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [DEFAULT]/kombu_ssl_ca_certs
+#kombu_ssl_ca_certs =
+
+# How long to wait before reconnecting in response to an AMQP consumer cancel
+# notification. (floating point value)
+# Deprecated group/name - [DEFAULT]/kombu_reconnect_delay
+#kombu_reconnect_delay = 1.0
+
+# EXPERIMENTAL: Possible values are: gzip, bz2. If not set compression will not
+# be used. This option may not be available in future versions. (string value)
+#kombu_compression = <None>
+
+# How long to wait a missing client before abandoning to send it its replies.
+# This value should not be longer than rpc_response_timeout. (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_reconnect_timeout
+#kombu_missing_consumer_retry_timeout = 60
+
+# Determines how the next RabbitMQ node is chosen in case the one we are
+# currently connected to becomes unavailable. Takes effect only if more than
+# one RabbitMQ node is provided in config. (string value)
+# Allowed values: round-robin, shuffle
+#kombu_failover_strategy = round-robin
+
+# DEPRECATED: The RabbitMQ broker address where a single node is used. (string
+# value)
+# Deprecated group/name - [DEFAULT]/rabbit_host
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#rabbit_host = localhost
+
+# DEPRECATED: The RabbitMQ broker port where a single node is used. (port
+# value)
+# Minimum value: 0
+# Maximum value: 65535
+# Deprecated group/name - [DEFAULT]/rabbit_port
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#rabbit_port = 5672
+
+# DEPRECATED: RabbitMQ HA cluster host:port pairs. (list value)
+# Deprecated group/name - [DEFAULT]/rabbit_hosts
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#rabbit_hosts = $rabbit_host:$rabbit_port
+
+# Connect over SSL for RabbitMQ. (boolean value)
+# Deprecated group/name - [DEFAULT]/rabbit_use_ssl
+#rabbit_use_ssl = false
+
+# DEPRECATED: The RabbitMQ userid. (string value)
+# Deprecated group/name - [DEFAULT]/rabbit_userid
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#rabbit_userid = guest
+
+# DEPRECATED: The RabbitMQ password. (string value)
+# Deprecated group/name - [DEFAULT]/rabbit_password
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#rabbit_password = guest
+
+# The RabbitMQ login method. (string value)
+# Allowed values: PLAIN, AMQPLAIN, RABBIT-CR-DEMO
+# Deprecated group/name - [DEFAULT]/rabbit_login_method
+#rabbit_login_method = AMQPLAIN
+
+# DEPRECATED: The RabbitMQ virtual host. (string value)
+# Deprecated group/name - [DEFAULT]/rabbit_virtual_host
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by [DEFAULT]/transport_url
+#rabbit_virtual_host = /
+
+# How frequently to retry connecting with RabbitMQ. (integer value)
+#rabbit_retry_interval = 1
+
+# How long to backoff for between retries when connecting to RabbitMQ. (integer
+# value)
+# Deprecated group/name - [DEFAULT]/rabbit_retry_backoff
+#rabbit_retry_backoff = 2
+
+# Maximum interval of RabbitMQ connection retries. Default is 30 seconds.
+# (integer value)
+#rabbit_interval_max = 30
+
+# DEPRECATED: Maximum number of RabbitMQ connection retries. Default is 0
+# (infinite retry count). (integer value)
+# Deprecated group/name - [DEFAULT]/rabbit_max_retries
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#rabbit_max_retries = 0
+
+# Try to use HA queues in RabbitMQ (x-ha-policy: all). If you change this
+# option, you must wipe the RabbitMQ database. In RabbitMQ 3.0, queue mirroring
+# is no longer controlled by the x-ha-policy argument when declaring a queue.
+# If you just want to make sure that all queues (except those with auto-
+# generated names) are mirrored across all nodes, run: "rabbitmqctl set_policy
+# HA '^(?!amq\.).*' '{"ha-mode": "all"}' " (boolean value)
+# Deprecated group/name - [DEFAULT]/rabbit_ha_queues
+#rabbit_ha_queues = false
+
+# Positive integer representing duration in seconds for queue TTL (x-expires).
+# Queues which are unused for the duration of the TTL are automatically
+# deleted. The parameter affects only reply and fanout queues. (integer value)
+# Minimum value: 1
+#rabbit_transient_queues_ttl = 1800
+
+# Specifies the number of messages to prefetch. Setting to zero allows
+# unlimited messages. (integer value)
+#rabbit_qos_prefetch_count = 0
+
+# Number of seconds after which the Rabbit broker is considered down if
+# heartbeat's keep-alive fails (0 disable the heartbeat). EXPERIMENTAL (integer
+# value)
+#heartbeat_timeout_threshold = 60
+
+# How often times during the heartbeat_timeout_threshold we check the
+# heartbeat. (integer value)
+#heartbeat_rate = 2
+
+# Deprecated, use rpc_backend=kombu+memory or rpc_backend=fake (boolean value)
+# Deprecated group/name - [DEFAULT]/fake_rabbit
+#fake_rabbit = false
+
+# Maximum number of channels to allow (integer value)
+#channel_max = <None>
+
+# The maximum byte size for an AMQP frame (integer value)
+#frame_max = <None>
+
+# How often to send heartbeats for consumer's connections (integer value)
+#heartbeat_interval = 3
+
+# Enable SSL (boolean value)
+#ssl = <None>
+
+# Arguments passed to ssl.wrap_socket (dict value)
+#ssl_options = <None>
+
+# Set socket timeout in seconds for connection's socket (floating point value)
+#socket_timeout = 0.25
+
+# Set TCP_USER_TIMEOUT in seconds for connection's socket (floating point
+# value)
+#tcp_user_timeout = 0.25
+
+# Set delay for reconnection to some host which has connection error (floating
+# point value)
+#host_connection_reconnect_delay = 0.25
+
+# Connection factory implementation (string value)
+# Allowed values: new, single, read_write
+#connection_factory = single
+
+# Maximum number of connections to keep queued. (integer value)
+#pool_max_size = 30
+
+# Maximum number of connections to create above `pool_max_size`. (integer
+# value)
+#pool_max_overflow = 0
+
+# Default number of seconds to wait for a connections to available (integer
+# value)
+#pool_timeout = 30
+
+# Lifetime of a connection (since creation) in seconds or None for no
+# recycling. Expired connections are closed on acquire. (integer value)
+#pool_recycle = 600
+
+# Threshold at which inactive (since release) connections are considered stale
+# in seconds or None for no staleness. Stale connections are closed on acquire.
+# (integer value)
+#pool_stale = 60
+
+# Default serialization mechanism for serializing/deserializing
+# outgoing/incoming messages (string value)
+# Allowed values: json, msgpack
+#default_serializer_type = json
+
+# Persist notification messages. (boolean value)
+#notification_persistence = false
+
+# Exchange name for sending notifications (string value)
+#default_notification_exchange = ${control_exchange}_notification
+
+# Max number of not acknowledged message which RabbitMQ can send to
+# notification listener. (integer value)
+#notification_listener_prefetch_count = 100
+
+# Reconnecting retry count in case of connectivity problem during sending
+# notification, -1 means infinite retry. (integer value)
+#default_notification_retry_attempts = -1
+
+# Reconnecting retry delay in case of connectivity problem during sending
+# notification message (floating point value)
+#notification_retry_delay = 0.25
+
+# Time to live for rpc queues without consumers in seconds. (integer value)
+#rpc_queue_expiration = 60
+
+# Exchange name for sending RPC messages (string value)
+#default_rpc_exchange = ${control_exchange}_rpc
+
+# Exchange name for receiving RPC replies (string value)
+#rpc_reply_exchange = ${control_exchange}_rpc_reply
+
+# Max number of not acknowledged message which RabbitMQ can send to rpc
+# listener. (integer value)
+#rpc_listener_prefetch_count = 100
+
+# Max number of not acknowledged message which RabbitMQ can send to rpc reply
+# listener. (integer value)
+#rpc_reply_listener_prefetch_count = 100
+
+# Reconnecting retry count in case of connectivity problem during sending
+# reply. -1 means infinite retry during rpc_timeout (integer value)
+#rpc_reply_retry_attempts = -1
+
+# Reconnecting retry delay in case of connectivity problem during sending
+# reply. (floating point value)
+#rpc_reply_retry_delay = 0.25
+
+# Reconnecting retry count in case of connectivity problem during sending RPC
+# message, -1 means infinite retry. If actual retry attempts in not 0 the rpc
+# request could be processed more than one time (integer value)
+#default_rpc_retry_attempts = -1
+
+# Reconnecting retry delay in case of connectivity problem during sending RPC
+# message (floating point value)
+#rpc_retry_delay = 0.25
+
+
+[oslo_messaging_zmq]
+
+#
+# From oslo.messaging
+#
+
+# ZeroMQ bind address. Should be a wildcard (*), an ethernet interface, or IP.
+# The "host" option should point or resolve to this address. (string value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_bind_address
+#rpc_zmq_bind_address = *
+
+# MatchMaker driver. (string value)
+# Allowed values: redis, sentinel, dummy
+# Deprecated group/name - [DEFAULT]/rpc_zmq_matchmaker
+#rpc_zmq_matchmaker = redis
+
+# Number of ZeroMQ contexts, defaults to 1. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_contexts
+#rpc_zmq_contexts = 1
+
+# Maximum number of ingress messages to locally buffer per topic. Default is
+# unlimited. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_topic_backlog
+#rpc_zmq_topic_backlog = <None>
+
+# Directory for holding IPC sockets. (string value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_ipc_dir
+#rpc_zmq_ipc_dir = /var/run/openstack
+
+# Name of this node. Must be a valid hostname, FQDN, or IP address. Must match
+# "host" option, if running Nova. (string value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_host
+#rpc_zmq_host = localhost
+
+# Number of seconds to wait before all pending messages will be sent after
+# closing a socket. The default value of -1 specifies an infinite linger
+# period. The value of 0 specifies no linger period. Pending messages shall be
+# discarded immediately when the socket is closed. Positive values specify an
+# upper bound for the linger period. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_cast_timeout
+#zmq_linger = -1
+
+# The default number of seconds that poll should wait. Poll raises timeout
+# exception when timeout expired. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_poll_timeout
+#rpc_poll_timeout = 1
+
+# Expiration timeout in seconds of a name service record about existing target
+# ( < 0 means no timeout). (integer value)
+# Deprecated group/name - [DEFAULT]/zmq_target_expire
+#zmq_target_expire = 300
+
+# Update period in seconds of a name service record about existing target.
+# (integer value)
+# Deprecated group/name - [DEFAULT]/zmq_target_update
+#zmq_target_update = 180
+
+# Use PUB/SUB pattern for fanout methods. PUB/SUB always uses proxy. (boolean
+# value)
+# Deprecated group/name - [DEFAULT]/use_pub_sub
+#use_pub_sub = false
+
+# Use ROUTER remote proxy. (boolean value)
+# Deprecated group/name - [DEFAULT]/use_router_proxy
+#use_router_proxy = false
+
+# This option makes direct connections dynamic or static. It makes sense only
+# with use_router_proxy=False which means to use direct connections for direct
+# message types (ignored otherwise). (boolean value)
+#use_dynamic_connections = false
+
+# How many additional connections to a host will be made for failover reasons.
+# This option is actual only in dynamic connections mode. (integer value)
+#zmq_failover_connections = 2
+
+# Minimal port number for random ports range. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+# Deprecated group/name - [DEFAULT]/rpc_zmq_min_port
+#rpc_zmq_min_port = 49153
+
+# Maximal port number for random ports range. (integer value)
+# Minimum value: 1
+# Maximum value: 65536
+# Deprecated group/name - [DEFAULT]/rpc_zmq_max_port
+#rpc_zmq_max_port = 65536
+
+# Number of retries to find free port number before fail with ZMQBindError.
+# (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_zmq_bind_port_retries
+#rpc_zmq_bind_port_retries = 100
+
+# Default serialization mechanism for serializing/deserializing
+# outgoing/incoming messages (string value)
+# Allowed values: json, msgpack
+# Deprecated group/name - [DEFAULT]/rpc_zmq_serialization
+#rpc_zmq_serialization = json
+
+# This option configures round-robin mode in zmq socket. True means not keeping
+# a queue when server side disconnects. False means to keep queue and messages
+# even if server is disconnected, when the server appears we send all
+# accumulated messages to it. (boolean value)
+#zmq_immediate = true
+
+# Enable/disable TCP keepalive (KA) mechanism. The default value of -1 (or any
+# other negative value) means to skip any overrides and leave it to OS default;
+# 0 and 1 (or any other positive value) mean to disable and enable the option
+# respectively. (integer value)
+#zmq_tcp_keepalive = -1
+
+# The duration between two keepalive transmissions in idle condition. The unit
+# is platform dependent, for example, seconds in Linux, milliseconds in Windows
+# etc. The default value of -1 (or any other negative value and 0) means to
+# skip any overrides and leave it to OS default. (integer value)
+#zmq_tcp_keepalive_idle = -1
+
+# The number of retransmissions to be carried out before declaring that remote
+# end is not available. The default value of -1 (or any other negative value
+# and 0) means to skip any overrides and leave it to OS default. (integer
+# value)
+#zmq_tcp_keepalive_cnt = -1
+
+# The duration between two successive keepalive retransmissions, if
+# acknowledgement to the previous keepalive transmission is not received. The
+# unit is platform dependent, for example, seconds in Linux, milliseconds in
+# Windows etc. The default value of -1 (or any other negative value and 0)
+# means to skip any overrides and leave it to OS default. (integer value)
+#zmq_tcp_keepalive_intvl = -1
+
+# Maximum number of (green) threads to work concurrently. (integer value)
+#rpc_thread_pool_size = 100
+
+# Expiration timeout in seconds of a sent/received message after which it is
+# not tracked anymore by a client/server. (integer value)
+#rpc_message_ttl = 300
+
+# Wait for message acknowledgements from receivers. This mechanism works only
+# via proxy without PUB/SUB. (boolean value)
+#rpc_use_acks = false
+
+# Number of seconds to wait for an ack from a cast/call. After each retry
+# attempt this timeout is multiplied by some specified multiplier. (integer
+# value)
+#rpc_ack_timeout_base = 15
+
+# Number to multiply base ack timeout by after each retry attempt. (integer
+# value)
+#rpc_ack_timeout_multiplier = 2
+
+# Default number of message sending attempts in case of any problems occurred:
+# positive value N means at most N retries, 0 means no retries, None or -1 (or
+# any other negative values) mean to retry forever. This option is used only if
+# acknowledgments are enabled. (integer value)
+#rpc_retry_attempts = 3
+
+# List of publisher hosts SubConsumer can subscribe on. This option has higher
+# priority then the default publishers list taken from the matchmaker. (list
+# value)
+#subscribe_on =
+
+
+[oslo_middleware]
+
+#
+# From oslo.middleware
+#
+
+# The maximum body size for each  request, in bytes. (integer value)
+# Deprecated group/name - [DEFAULT]/osapi_max_request_body_size
+# Deprecated group/name - [DEFAULT]/max_request_body_size
+#max_request_body_size = 114688
+
+# DEPRECATED: The HTTP Header that will be used to determine what the original
+# request protocol scheme was, even if it was hidden by a SSL termination
+# proxy. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#secure_proxy_ssl_header = X-Forwarded-Proto
+
+# Whether the application is behind a proxy or not. This determines if the
+# middleware should parse the headers or not. (boolean value)
+#enable_proxy_headers_parsing = false
+
+
+[oslo_policy]
+
+#
+# From oslo.policy
+#
+
+# The file that defines policies. (string value)
+# Deprecated group/name - [DEFAULT]/policy_file
+#policy_file = policy.json
+
+# Default rule. Enforced when a requested rule is not found. (string value)
+# Deprecated group/name - [DEFAULT]/policy_default_rule
+#policy_default_rule = default
+
+# Directories where policy configuration files are stored. They can be relative
+# to any directory in the search path defined by the config_dir option, or
+# absolute paths. The file defined by policy_file must exist for these
+# directories to be searched.  Missing or empty directories are ignored. (multi
+# valued)
+# Deprecated group/name - [DEFAULT]/policy_dirs
+#policy_dirs = policy.d
+
+
+[paste_deploy]
+
+#
+# From keystone
+#
+
+# Name of (or absolute path to) the Paste Deploy configuration file that
+# composes middleware and the keystone application itself into actual WSGI
+# entry points. See http://pythonpaste.org/deploy/ for additional documentation
+# on the file's format. (string value)
+#config_file = keystone-paste.ini
+
+
+[policy]
+
+#
+# From keystone
+#
+
+# Entry point for the policy backend driver in the `keystone.policy` namespace.
+# Supplied drivers are `rules` (which does not support any CRUD operations for
+# the v3 policy API) and `sql`. Typically, there is no reason to set this
+# option unless you are providing a custom entry point. (string value)
+#driver = sql
+
+# Maximum number of entities that will be returned in a policy collection.
+# (integer value)
+#list_limit = <None>
+
+
+[profiler]
+
+#
+# From osprofiler
+#
+
+#
+# Enables the profiling for all services on this node. Default value is False
+# (fully disable the profiling feature).
+#
+# Possible values:
+#
+# * True: Enables the feature
+# * False: Disables the feature. The profiling cannot be started via this
+# project
+# operations. If the profiling is triggered by another project, this project
+# part
+# will be empty.
+#  (boolean value)
+# Deprecated group/name - [profiler]/profiler_enabled
+#enabled = false
+
+#
+# Enables SQL requests profiling in services. Default value is False (SQL
+# requests won't be traced).
+#
+# Possible values:
+#
+# * True: Enables SQL requests profiling. Each SQL query will be part of the
+# trace and can the be analyzed by how much time was spent for that.
+# * False: Disables SQL requests profiling. The spent time is only shown on a
+# higher level of operations. Single SQL queries cannot be analyzed this
+# way.
+#  (boolean value)
+#trace_sqlalchemy = false
+
+#
+# Secret key(s) to use for encrypting context data for performance profiling.
+# This string value should have the following format:
+# <key1>[,<key2>,...<keyn>],
+# where each key is some random string. A user who triggers the profiling via
+# the REST API has to set one of these keys in the headers of the REST API call
+# to include profiling results of this node for this particular project.
+#
+# Both "enabled" flag and "hmac_keys" config options should be set to enable
+# profiling. Also, to generate correct profiling information across all
+# services
+# at least one key needs to be consistent between OpenStack projects. This
+# ensures it can be used from client side to generate the trace, containing
+# information from all possible resources. (string value)
+#hmac_keys = SECRET_KEY
+
+#
+# Connection string for a notifier backend. Default value is messaging:// which
+# sets the notifier to oslo_messaging.
+#
+# Examples of possible values:
+#
+# * messaging://: use oslo_messaging driver for sending notifications.
+# * mongodb://127.0.0.1:27017 : use mongodb driver for sending notifications.
+# * elasticsearch://127.0.0.1:9200 : use elasticsearch driver for sending
+# notifications.
+#  (string value)
+#connection_string = messaging://
+
+#
+# Document type for notification indexing in elasticsearch.
+#  (string value)
+#es_doc_type = notification
+
+#
+# This parameter is a time value parameter (for example: es_scroll_time=2m),
+# indicating for how long the nodes that participate in the search will
+# maintain
+# relevant resources in order to continue and support it.
+#  (string value)
+#es_scroll_time = 2m
+
+#
+# Elasticsearch splits large requests in batches. This parameter defines
+# maximum size of each batch (for example: es_scroll_size=10000).
+#  (integer value)
+#es_scroll_size = 10000
+
+#
+# Redissentinel provides a timeout option on the connections.
+# This parameter defines that timeout (for example: socket_timeout=0.1).
+#  (floating point value)
+#socket_timeout = 0.1
+
+#
+# Redissentinel uses a service name to identify a master redis service.
+# This parameter defines the name (for example:
+# sentinal_service_name=mymaster).
+#  (string value)
+#sentinel_service_name = mymaster
+
+
+[resource]
+
+#
+# From keystone
+#
+
+# Entry point for the resource driver in the `keystone.resource` namespace.
+# Only a `sql` driver is supplied by keystone. Unless you are writing
+# proprietary drivers for keystone, you do not need to set this option. (string
+# value)
+#driver = sql
+
+# Toggle for resource caching. This has no effect unless global caching is
+# enabled. (boolean value)
+# Deprecated group/name - [assignment]/caching
+#caching = true
+
+# Time to cache resource data in seconds. This has no effect unless global
+# caching is enabled. (integer value)
+# Deprecated group/name - [assignment]/cache_time
+#cache_time = <None>
+
+# Maximum number of entities that will be returned in a resource collection.
+# (integer value)
+# Deprecated group/name - [assignment]/list_limit
+#list_limit = <None>
+
+# Name of the domain that owns the `admin_project_name`. If left unset, then
+# there is no admin project. `[resource] admin_project_name` must also be set
+# to use this option. (string value)
+#admin_project_domain_name = <None>
+
+# This is a special project which represents cloud-level administrator
+# privileges across services. Tokens scoped to this project will contain a true
+# `is_admin_project` attribute to indicate to policy systems that the role
+# assignments on that specific project should apply equally across every
+# project. If left unset, then there is no admin project, and thus no explicit
+# means of cross-project role assignments. `[resource]
+# admin_project_domain_name` must also be set to use this option. (string
+# value)
+#admin_project_name = <None>
+
+# This controls whether the names of projects are restricted from containing
+# URL-reserved characters. If set to `new`, attempts to create or update a
+# project with a URL-unsafe name will fail. If set to `strict`, attempts to
+# scope a token with a URL-unsafe project name will fail, thereby forcing all
+# project names to be updated to be URL-safe. (string value)
+# Allowed values: off, new, strict
+#project_name_url_safe = off
+
+# This controls whether the names of domains are restricted from containing
+# URL-reserved characters. If set to `new`, attempts to create or update a
+# domain with a URL-unsafe name will fail. If set to `strict`, attempts to
+# scope a token with a URL-unsafe domain name will fail, thereby forcing all
+# domain names to be updated to be URL-safe. (string value)
+# Allowed values: off, new, strict
+#domain_name_url_safe = off
+
+
+[revoke]
+
+#
+# From keystone
+#
+
+# Entry point for the token revocation backend driver in the `keystone.revoke`
+# namespace. Keystone only provides a `sql` driver, so there is no reason to
+# set this option unless you are providing a custom entry point. (string value)
+#driver = sql
+
+# The number of seconds after a token has expired before a corresponding
+# revocation event may be purged from the backend. (integer value)
+# Minimum value: 0
+#expiration_buffer = 1800
+
+# Toggle for revocation event caching. This has no effect unless global caching
+# is enabled. (boolean value)
+#caching = true
+
+# Time to cache the revocation list and the revocation events (in seconds).
+# This has no effect unless global and `[revoke] caching` are both enabled.
+# (integer value)
+# Deprecated group/name - [token]/revocation_cache_time
+#cache_time = 3600
+
+
+[role]
+
+#
+# From keystone
+#
+
+# Entry point for the role backend driver in the `keystone.role` namespace.
+# Keystone only provides a `sql` driver, so there's no reason to change this
+# unless you are providing a custom entry point. (string value)
+#driver = <None>
+
+# Toggle for role caching. This has no effect unless global caching is enabled.
+# In a typical deployment, there is no reason to disable this. (boolean value)
+#caching = true
+
+# Time to cache role data, in seconds. This has no effect unless both global
+# caching and `[role] caching` are enabled. (integer value)
+#cache_time = <None>
+
+# Maximum number of entities that will be returned in a role collection. This
+# may be useful to tune if you have a large number of discrete roles in your
+# deployment. (integer value)
+#list_limit = <None>
+
+
+[saml]
+
+#
+# From keystone
+#
+
+# Determines the lifetime for any SAML assertions generated by keystone, using
+# `NotOnOrAfter` attributes. (integer value)
+#assertion_expiration_time = 3600
+
+# Name of, or absolute path to, the binary to be used for XML signing. Although
+# only the XML Security Library (`xmlsec1`) is supported, it may have a non-
+# standard name or path on your system. If keystone cannot find the binary
+# itself, you may need to install the appropriate package, use this option to
+# specify an absolute path, or adjust keystone's PATH environment variable.
+# (string value)
+#xmlsec1_binary = xmlsec1
+
+# Absolute path to the public certificate file to use for SAML signing. The
+# value cannot contain a comma (`,`). (string value)
+#certfile = /etc/keystone/ssl/certs/signing_cert.pem
+
+# Absolute path to the private key file to use for SAML signing. The value
+# cannot contain a comma (`,`). (string value)
+#keyfile = /etc/keystone/ssl/private/signing_key.pem
+
+# This is the unique entity identifier of the identity provider (keystone) to
+# use when generating SAML assertions. This value is required to generate
+# identity provider metadata and must be a URI (a URL is recommended). For
+# example: `https://keystone.example.com/v3/OS-FEDERATION/saml2/idp`. (uri
+# value)
+#idp_entity_id = <None>
+
+# This is the single sign-on (SSO) service location of the identity provider
+# which accepts HTTP POST requests. A value is required to generate identity
+# provider metadata. For example: `https://keystone.example.com/v3/OS-
+# FEDERATION/saml2/sso`. (uri value)
+#idp_sso_endpoint = <None>
+
+# This is the language used by the identity provider's organization. (string
+# value)
+#idp_lang = en
+
+# This is the name of the identity provider's organization. (string value)
+#idp_organization_name = SAML Identity Provider
+
+# This is the name of the identity provider's organization to be displayed.
+# (string value)
+#idp_organization_display_name = OpenStack SAML Identity Provider
+
+# This is the URL of the identity provider's organization. The URL referenced
+# here should be useful to humans. (uri value)
+#idp_organization_url = https://example.com/
+
+# This is the company name of the identity provider's contact person. (string
+# value)
+#idp_contact_company = Example, Inc.
+
+# This is the given name of the identity provider's contact person. (string
+# value)
+#idp_contact_name = SAML Identity Provider Support
+
+# This is the surname of the identity provider's contact person. (string value)
+#idp_contact_surname = Support
+
+# This is the email address of the identity provider's contact person. (string
+# value)
+#idp_contact_email = support@example.com
+
+# This is the telephone number of the identity provider's contact person.
+# (string value)
+#idp_contact_telephone = +1 800 555 0100
+
+# This is the type of contact that best describes the identity provider's
+# contact person. (string value)
+# Allowed values: technical, support, administrative, billing, other
+#idp_contact_type = other
+
+# Absolute path to the identity provider metadata file. This file should be
+# generated with the `keystone-manage saml_idp_metadata` command. There is
+# typically no reason to change this value. (string value)
+#idp_metadata_path = /etc/keystone/saml2_idp_metadata.xml
+
+# The prefix of the RelayState SAML attribute to use when generating enhanced
+# client and proxy (ECP) assertions. In a typical deployment, there is no
+# reason to change this value. (string value)
+#relay_state_prefix = ss:mem:
+
+
+[security_compliance]
+
+#
+# From keystone
+#
+
+# The maximum number of days a user can go without authenticating before being
+# considered "inactive" and automatically disabled (locked). This feature is
+# disabled by default; set any value to enable it. This feature depends on the
+# `sql` backend for the `[identity] driver`. When a user exceeds this threshold
+# and is considered "inactive", the user's `enabled` attribute in the HTTP API
+# may not match the value of the user's `enabled` column in the user table.
+# (integer value)
+# Minimum value: 1
+#disable_user_account_days_inactive = <None>
+
+# The maximum number of times that a user can fail to authenticate before the
+# user account is locked for the number of seconds specified by
+# `[security_compliance] lockout_duration`. This feature is disabled by
+# default. If this feature is enabled and `[security_compliance]
+# lockout_duration` is not set, then users may be locked out indefinitely until
+# the user is explicitly enabled via the API. This feature depends on the `sql`
+# backend for the `[identity] driver`. (integer value)
+# Minimum value: 1
+#lockout_failure_attempts = <None>
+
+# The number of seconds a user account will be locked when the maximum number
+# of failed authentication attempts (as specified by `[security_compliance]
+# lockout_failure_attempts`) is exceeded. Setting this option will have no
+# effect unless you also set `[security_compliance] lockout_failure_attempts`
+# to a non-zero value. This feature depends on the `sql` backend for the
+# `[identity] driver`. (integer value)
+# Minimum value: 1
+#lockout_duration = 1800
+
+# The number of days for which a password will be considered valid before
+# requiring it to be changed. This feature is disabled by default. If enabled,
+# new password changes will have an expiration date, however existing passwords
+# would not be impacted. This feature depends on the `sql` backend for the
+# `[identity] driver`. (integer value)
+# Minimum value: 1
+#password_expires_days = <None>
+
+# DEPRECATED: Comma separated list of user IDs to be ignored when checking if a
+# password is expired. Passwords for users in this list will not expire. This
+# feature will only be enabled if `[security_compliance] password_expires_days`
+# is set. (list value)
+# This option is deprecated for removal since O.
+# Its value may be silently ignored in the future.
+# Reason: Functionality added as a per-user option "ignore_password_expiry" in
+# Ocata. Each user that should ignore password expiry should have the value set
+# to "true" in the user's `options` attribute (e.g.
+# `user['options']['ignore_password_expiry'] = True`) with an "update_user"
+# call. This avoids the need to restart keystone to adjust the users that
+# ignore password expiry. This option will be removed in the Pike release.
+#password_expires_ignore_user_ids =
+
+# This controls the number of previous user password iterations to keep in
+# history, in order to enforce that newly created passwords are unique. Setting
+# the value to one (the default) disables this feature. Thus, to enable this
+# feature, values must be greater than 1. This feature depends on the `sql`
+# backend for the `[identity] driver`. (integer value)
+# Minimum value: 1
+#unique_last_password_count = 1
+
+# The number of days that a password must be used before the user can change
+# it. This prevents users from changing their passwords immediately in order to
+# wipe out their password history and reuse an old password. This feature does
+# not prevent administrators from manually resetting passwords. It is disabled
+# by default and allows for immediate password changes. This feature depends on
+# the `sql` backend for the `[identity] driver`. Note: If
+# `[security_compliance] password_expires_days` is set, then the value for this
+# option should be less than the `password_expires_days`. (integer value)
+# Minimum value: 0
+#minimum_password_age = 0
+
+# The regular expression used to validate password strength requirements. By
+# default, the regular expression will match any password. The following is an
+# example of a pattern which requires at least 1 letter, 1 digit, and have a
+# minimum length of 7 characters: ^(?=.*\d)(?=.*[a-zA-Z]).{7,}$ This feature
+# depends on the `sql` backend for the `[identity] driver`. (string value)
+#password_regex = <None>
+
+# Describe your password regular expression here in language for humans. If a
+# password fails to match the regular expression, the contents of this
+# configuration variable will be returned to users to explain why their
+# requested password was insufficient. (string value)
+#password_regex_description = <None>
+
+# Enabling this option requires users to change their password when the user is
+# created, or upon administrative reset. Before accessing any services,
+# affected users will have to change their password. To ignore this requirement
+# for specific users, such as service users, set the `options` attribute
+# `ignore_change_password_upon_first_use` to `True` for the desired user via
+# the update user API. This feature is disabled by default. This feature is
+# only applicable with the `sql` backend for the `[identity] driver`. (boolean
+# value)
+#change_password_upon_first_use = false
+
+
+[shadow_users]
+
+#
+# From keystone
+#
+
+# Entry point for the shadow users backend driver in the
+# `keystone.identity.shadow_users` namespace. This driver is used for
+# persisting local user references to externally-managed identities (via
+# federation, LDAP, etc). Keystone only provides a `sql` driver, so there is no
+# reason to change this option unless you are providing a custom entry point.
+# (string value)
+#driver = sql
+
+
+[signing]
+
+#
+# From keystone
+#
+
+# Absolute path to the public certificate file to use for signing responses to
+# revocation lists requests. Set this together with `[signing] keyfile`. For
+# non-production environments, you may be interested in using `keystone-manage
+# pki_setup` to generate self-signed certificates. (string value)
+#certfile = /etc/keystone/ssl/certs/signing_cert.pem
+
+# Absolute path to the private key file to use for signing responses to
+# revocation lists requests. Set this together with `[signing] certfile`.
+# (string value)
+#keyfile = /etc/keystone/ssl/private/signing_key.pem
+
+# Absolute path to the public certificate authority (CA) file to use when
+# creating self-signed certificates with `keystone-manage pki_setup`. Set this
+# together with `[signing] ca_key`. There is no reason to set this option
+# unless you are requesting revocation lists in a non-production environment.
+# Use a `[signing] certfile` issued from a trusted certificate authority
+# instead. (string value)
+#ca_certs = /etc/keystone/ssl/certs/ca.pem
+
+# Absolute path to the private certificate authority (CA) key file to use when
+# creating self-signed certificates with `keystone-manage pki_setup`. Set this
+# together with `[signing] ca_certs`. There is no reason to set this option
+# unless you are requesting revocation lists in a non-production environment.
+# Use a `[signing] certfile` issued from a trusted certificate authority
+# instead. (string value)
+#ca_key = /etc/keystone/ssl/private/cakey.pem
+
+# Key size (in bits) to use when generating a self-signed token signing
+# certificate. There is no reason to set this option unless you are requesting
+# revocation lists in a non-production environment. Use a `[signing] certfile`
+# issued from a trusted certificate authority instead. (integer value)
+# Minimum value: 1024
+#key_size = 2048
+
+# The validity period (in days) to use when generating a self-signed token
+# signing certificate. There is no reason to set this option unless you are
+# requesting revocation lists in a non-production environment. Use a `[signing]
+# certfile` issued from a trusted certificate authority instead. (integer
+# value)
+#valid_days = 3650
+
+# The certificate subject to use when generating a self-signed token signing
+# certificate. There is no reason to set this option unless you are requesting
+# revocation lists in a non-production environment. Use a `[signing] certfile`
+# issued from a trusted certificate authority instead. (string value)
+#cert_subject = /C=US/ST=Unset/L=Unset/O=Unset/CN=www.example.com
+
+
+[token]
+
+#
+# From keystone
+#
+
+# This is a list of external authentication mechanisms which should add token
+# binding metadata to tokens, such as `kerberos` or `x509`. Binding metadata is
+# enforced according to the `[token] enforce_token_bind` option. (list value)
+#bind =
+
+# This controls the token binding enforcement policy on tokens presented to
+# keystone with token binding metadata (as specified by the `[token] bind`
+# option). `disabled` completely bypasses token binding validation.
+# `permissive` and `strict` do not require tokens to have binding metadata (but
+# will validate it if present), whereas `required` will always demand tokens to
+# having binding metadata. `permissive` will allow unsupported binding metadata
+# to pass through without validation (usually to be validated at another time
+# by another component), whereas `strict` and `required` will demand that the
+# included binding metadata be supported by keystone. (string value)
+# Allowed values: disabled, permissive, strict, required
+#enforce_token_bind = permissive
+
+# The amount of time that a token should remain valid (in seconds). Drastically
+# reducing this value may break "long-running" operations that involve multiple
+# services to coordinate together, and will force users to authenticate with
+# keystone more frequently. Drastically increasing this value will increase
+# load on the `[token] driver`, as more tokens will be simultaneously valid.
+# Keystone tokens are also bearer tokens, so a shorter duration will also
+# reduce the potential security impact of a compromised token. (integer value)
+# Minimum value: 0
+# Maximum value: 9223372036854775807
+#expiration = 3600
+
+# Entry point for the token provider in the `keystone.token.provider`
+# namespace. The token provider controls the token construction, validation,
+# and revocation operations. Keystone includes `fernet` and `uuid` token
+# providers. `uuid` tokens must be persisted (using the backend specified in
+# the `[token] driver` option), but do not require any extra configuration or
+# setup. `fernet` tokens do not need to be persisted at all, but require that
+# you run `keystone-manage fernet_setup` (also see the `keystone-manage
+# fernet_rotate` command). (string value)
+#provider = fernet
+provider = fernet
+
+# Entry point for the token persistence backend driver in the
+# `keystone.token.persistence` namespace. Keystone provides `kvs` and `sql`
+# drivers. The `kvs` backend depends on the configuration in the `[kvs]`
+# section. The `sql` option (default) depends on the options in your
+# `[database]` section. If you're using the `fernet` `[token] provider`, this
+# backend will not be utilized to persist tokens at all. (string value)
+#driver = sql
+
+# Toggle for caching token creation and validation data. This has no effect
+# unless global caching is enabled. (boolean value)
+#caching = true
+
+# The number of seconds to cache token creation and validation data. This has
+# no effect unless both global and `[token] caching` are enabled. (integer
+# value)
+# Minimum value: 0
+# Maximum value: 9223372036854775807
+#cache_time = <None>
+
+# This toggles support for revoking individual tokens by the token identifier
+# and thus various token enumeration operations (such as listing all tokens
+# issued to a specific user). These operations are used to determine the list
+# of tokens to consider revoked. Do not disable this option if you're using the
+# `kvs` `[revoke] driver`. (boolean value)
+#revoke_by_id = true
+
+# This toggles whether scoped tokens may be be re-scoped to a new project or
+# domain, thereby preventing users from exchanging a scoped token (including
+# those with a default project scope) for any other token. This forces users to
+# either authenticate for unscoped tokens (and later exchange that unscoped
+# token for tokens with a more specific scope) or to provide their credentials
+# in every request for a scoped token to avoid re-scoping altogether. (boolean
+# value)
+#allow_rescope_scoped_token = true
+
+# This controls whether roles should be included with tokens that are not
+# directly assigned to the token's scope, but are instead linked implicitly to
+# other role assignments. (boolean value)
+#infer_roles = true
+
+# Enable storing issued token data to token validation cache so that first
+# token validation doesn't actually cause full validation cycle. This option
+# has no effect unless global caching and token caching are enabled. (boolean
+# value)
+#cache_on_issue = true
+
+# This controls the number of seconds that a token can be retrieved for beyond
+# the built-in expiry time. This allows long running operations to succeed.
+# Defaults to two days. (integer value)
+#allow_expired_window = 172800
+
+
+[tokenless_auth]
+
+#
+# From keystone
+#
+
+# The list of distinguished names which identify trusted issuers of client
+# certificates allowed to use X.509 tokenless authorization. If the option is
+# absent then no certificates will be allowed. The format for the values of a
+# distinguished name (DN) must be separated by a comma and contain no spaces.
+# Furthermore, because an individual DN may contain commas, this configuration
+# option may be repeated multiple times to represent multiple values. For
+# example, keystone.conf would include two consecutive lines in order to trust
+# two different DNs, such as `trusted_issuer = CN=john,OU=keystone,O=openstack`
+# and `trusted_issuer = CN=mary,OU=eng,O=abc`. (multi valued)
+#trusted_issuer =
+
+# The federated protocol ID used to represent X.509 tokenless authorization.
+# This is used in combination with the value of `[tokenless_auth]
+# issuer_attribute` to find a corresponding federated mapping. In a typical
+# deployment, there is no reason to change this value. (string value)
+#protocol = x509
+
+# The name of the WSGI environment variable used to pass the issuer of the
+# client certificate to keystone. This attribute is used as an identity
+# provider ID for the X.509 tokenless authorization along with the protocol to
+# look up its corresponding mapping. In a typical deployment, there is no
+# reason to change this value. (string value)
+#issuer_attribute = SSL_CLIENT_I_DN
+
+
+[trust]
+
+#
+# From keystone
+#
+
+# Delegation and impersonation features using trusts can be optionally
+# disabled. (boolean value)
+#enabled = true
+
+# Allows authorization to be redelegated from one user to another, effectively
+# chaining trusts together. When disabled, the `remaining_uses` attribute of a
+# trust is constrained to be zero. (boolean value)
+#allow_redelegation = false
+
+# Maximum number of times that authorization can be redelegated from one user
+# to another in a chain of trusts. This number may be reduced further for a
+# specific trust. (integer value)
+#max_redelegation_count = 3
+
+# Entry point for the trust backend driver in the `keystone.trust` namespace.
+# Keystone only provides a `sql` driver, so there is no reason to change this
+# unless you are providing a custom entry point. (string value)
+#driver = sql

--- a/rocky/l3_agent.ini
+++ b/rocky/l3_agent.ini
@@ -1,0 +1,267 @@
+[DEFAULT]
+interface_driver = linuxbridge
+external_network_bridge =
+
+#
+# From neutron.base.agent
+#
+
+# Name of Open vSwitch bridge to use (string value)
+#ovs_integration_bridge = br-int
+
+# Uses veth for an OVS interface or not. Support kernels with limited namespace
+# support (e.g. RHEL 6.5) so long as ovs_use_veth is set to True. (boolean
+# value)
+#ovs_use_veth = false
+
+# MTU setting for device. This option will be removed in Newton. Please use the
+# system-wide global_physnet_mtu setting which the agents will take into
+# account when wiring VIFs. (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#network_device_mtu = <None>
+
+# The driver used to manage the virtual interface. (string value)
+#interface_driver = <None>
+
+# Timeout in seconds for ovs-vsctl commands. If the timeout expires, ovs
+# commands will fail with ALARMCLOCK error. (integer value)
+#ovs_vsctl_timeout = 10
+
+#
+# From neutron.l3.agent
+#
+
+# The working mode for the agent. Allowed modes are: 'legacy' - this preserves
+# the existing behavior where the L3 agent is deployed on a centralized
+# networking node to provide L3 services like DNAT, and SNAT. Use this mode if
+# you do not want to adopt DVR. 'dvr' - this mode enables DVR functionality and
+# must be used for an L3 agent that runs on a compute host. 'dvr_snat' - this
+# enables centralized SNAT support in conjunction with DVR.  This mode must be
+# used for an L3 agent running on a centralized node (or in single-host
+# deployments, e.g. devstack) (string value)
+# Allowed values: dvr, dvr_snat, legacy
+#agent_mode = legacy
+
+# TCP Port used by Neutron metadata namespace proxy. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#metadata_port = 9697
+
+# Send this many gratuitous ARPs for HA setup, if less than or equal to 0, the
+# feature is disabled (integer value)
+#send_arp_for_ha = 3
+
+# If non-empty, the l3 agent can only configure a router that has the matching
+# router ID. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#router_id =
+
+# Indicates that this L3 agent should also handle routers that do not have an
+# external network gateway configured. This option should be True only for a
+# single agent in a Neutron deployment, and may be False for all agents if all
+# routers must have an external network gateway. (boolean value)
+#handle_internal_only_routers = true
+
+# When external_network_bridge is set, each L3 agent can be associated with no
+# more than one external network. This value should be set to the UUID of that
+# external network. To allow L3 agent support multiple external networks, both
+# the external_network_bridge and gateway_external_network_id must be left
+# empty. (string value)
+#gateway_external_network_id =
+
+# With IPv6, the network used for the external gateway does not need to have an
+# associated subnet, since the automatically assigned link-local address (LLA)
+# can be used. However, an IPv6 gateway address is needed for use as the next-
+# hop for the default route. If no IPv6 gateway address is configured here,
+# (and only then) the neutron router will be configured to get its default
+# route from router advertisements (RAs) from the upstream router; in which
+# case the upstream router must also be configured to send these RAs. The
+# ipv6_gateway, when configured, should be the LLA of the interface on the
+# upstream router. If a next-hop using a global unique address (GUA) is
+# desired, it needs to be done via a subnet allocated to the network and not
+# through this parameter.  (string value)
+#ipv6_gateway =
+
+# Driver used for ipv6 prefix delegation. This needs to be an entry point
+# defined in the neutron.agent.linux.pd_drivers namespace. See setup.cfg for
+# entry points included with the neutron source. (string value)
+#prefix_delegation_driver = dibbler
+
+# Allow running metadata proxy. (boolean value)
+#enable_metadata_proxy = true
+
+# Iptables mangle mark used to mark metadata valid requests. This mark will be
+# masked with 0xffff so that only the lower 16 bits will be used. (string
+# value)
+#metadata_access_mark = 0x1
+
+# Iptables mangle mark used to mark ingress from external network. This mark
+# will be masked with 0xffff so that only the lower 16 bits will be used.
+# (string value)
+#external_ingress_mark = 0x2
+
+# Name of bridge used for external network traffic. This should be set to an
+# empty value for the Linux Bridge. When this parameter is set, each L3 agent
+# can be associated with no more than one external network. (string value)
+#external_network_bridge = br-ex
+
+# Seconds between running periodic tasks (integer value)
+#periodic_interval = 40
+
+# Number of separate API worker processes for service. If not specified, the
+# default is equal to the number of CPUs available for best performance.
+# (integer value)
+#api_workers = <None>
+
+# Number of RPC worker processes for service (integer value)
+#rpc_workers = 1
+
+# Number of RPC worker processes dedicated to state reports queue (integer
+# value)
+#rpc_state_report_workers = 1
+
+# Range of seconds to randomly delay when starting the periodic task scheduler
+# to reduce stampeding. (Disable by setting to 0) (integer value)
+#periodic_fuzzy_delay = 5
+
+# Location to store keepalived/conntrackd config files (string value)
+#ha_confs_path = $state_path/ha_confs
+
+# VRRP authentication type (string value)
+# Allowed values: AH, PASS
+#ha_vrrp_auth_type = PASS
+
+# VRRP authentication password (string value)
+#ha_vrrp_auth_password = <None>
+
+# The advertisement interval in seconds (integer value)
+#ha_vrrp_advert_int = 2
+
+# Number of concurrent threads for keepalived server connection requests.More
+# threads create a higher CPU load on the agent node. (integer value)
+# Minimum value: 1
+#ha_keepalived_state_change_server_threads = 2
+
+# Service to handle DHCPv6 Prefix delegation. (string value)
+#pd_dhcp_driver = dibbler
+
+# Location to store IPv6 RA config files (string value)
+#ra_confs = $state_path/ra
+
+# MinRtrAdvInterval setting for radvd.conf (integer value)
+#min_rtr_adv_interval = 30
+
+# MaxRtrAdvInterval setting for radvd.conf (integer value)
+#max_rtr_adv_interval = 100
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of the default
+# INFO level. (boolean value)
+#debug = false
+
+# If set to false, the logging level will be set to WARNING instead of the
+# default INFO level. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#verbose = true
+
+# The name of a logging configuration file. This file is appended to any
+# existing logging configuration files. For details about logging configuration
+# files, see the Python logging module documentation. Note that when logging
+# configuration files are used then all logging configuration is set in the
+# configuration file and other logging configuration options are ignored (for
+# example, logging_context_format_string). (string value)
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set. (string
+# value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default is set,
+# logging will go to stderr as defined by use_stderr. This option is ignored if
+# log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths. This option
+# is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is moved or
+# removed this handler will open a new log file with specified path
+# instantaneously. It makes sense only if log_file option is specified and
+# Linux platform is used. This option is ignored if log_config_append is set.
+# (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and will be
+# changed later to honor RFC5424. This option is ignored if log_config_append
+# is set. (boolean value)
+#use_syslog = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Log output to standard error. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_stderr = true
+
+# Format string to use for log messages with context. (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined. (string
+# value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the message
+# is DEBUG. (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. (string value)
+#logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is ignored
+# if log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,dogpile.core.dogpile=INFO
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message. (string
+# value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message. (string
+# value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false
+
+
+[AGENT]
+
+#
+# From neutron.base.agent
+#
+
+# Seconds between nodes reporting state to server; should be less than
+# agent_down_time, best if it is half or less than agent_down_time. (floating
+# point value)
+#report_interval = 30
+
+# Log agent heartbeats (boolean value)
+#log_agent_heartbeats = false

--- a/rocky/lab_openrc.sh
+++ b/rocky/lab_openrc.sh
@@ -1,0 +1,4 @@
+export OS_USERNAME=admin
+export OS_AUTH_URL=http://openstack-controller.avi.local:5000/v2.0
+export OS_PASSWORD=avi123
+export OS_TENANT_NAME=admin

--- a/rocky/linuxbridge_agent.ini
+++ b/rocky/linuxbridge_agent.ini
@@ -1,0 +1,203 @@
+[DEFAULT]
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of the default
+# INFO level. (boolean value)
+#debug = false
+
+# If set to false, the logging level will be set to WARNING instead of the
+# default INFO level. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#verbose = true
+
+# The name of a logging configuration file. This file is appended to any
+# existing logging configuration files. For details about logging configuration
+# files, see the Python logging module documentation. Note that when logging
+# configuration files are used then all logging configuration is set in the
+# configuration file and other logging configuration options are ignored (for
+# example, logging_context_format_string). (string value)
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set. (string
+# value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default is set,
+# logging will go to stderr as defined by use_stderr. This option is ignored if
+# log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths. This option
+# is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is moved or
+# removed this handler will open a new log file with specified path
+# instantaneously. It makes sense only if log_file option is specified and
+# Linux platform is used. This option is ignored if log_config_append is set.
+# (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and will be
+# changed later to honor RFC5424. This option is ignored if log_config_append
+# is set. (boolean value)
+#use_syslog = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Log output to standard error. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_stderr = true
+
+# Format string to use for log messages with context. (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined. (string
+# value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the message
+# is DEBUG. (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. (string value)
+#logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is ignored
+# if log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,dogpile.core.dogpile=INFO
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message. (string
+# value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message. (string
+# value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false
+
+
+[agent]
+
+#
+# From neutron.ml2.linuxbridge.agent
+#
+
+# The number of seconds the agent will wait between polling for local device
+# changes. (integer value)
+#polling_interval = 2
+
+# Set new timeout in seconds for new rpc calls after agent receives SIGTERM. If
+# value is set to 0, rpc timeout won't be changed (integer value)
+#quitting_rpc_timeout = 10
+
+# Enable suppression of ARP responses that don't match an IP address that
+# belongs to the port from which they originate. Note: This prevents the VMs
+# attached to this agent from spoofing, it doesn't protect them from other
+# devices which have the capability to spoof (e.g. bare metal or VMs attached
+# to agents without this flag set to True). Spoofing rules will not be added to
+# any ports that have port security disabled. For LinuxBridge, this requires
+# ebtables. For OVS, it requires a version that supports matching ARP headers.
+# This option will be removed in Newton so the only way to disable protection
+# will be via the port security extension. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#prevent_arp_spoofing = true
+
+
+[linux_bridge]
+physical_interface_mappings = provider:ens4
+
+#
+# From neutron.ml2.linuxbridge.agent
+#
+
+# Comma-separated list of <physical_network>:<physical_interface> tuples
+# mapping physical network names to the agent's node-specific physical network
+# interfaces to be used for flat and VLAN networks. All physical networks
+# listed in network_vlan_ranges on the server should have mappings to
+# appropriate interfaces on each agent. (list value)
+#physical_interface_mappings =
+
+# List of <physical_network>:<physical_bridge> (list value)
+#bridge_mappings =
+
+
+[securitygroup]
+enable_security_group = True
+firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
+
+#
+# From neutron.ml2.linuxbridge.agent
+#
+
+# Driver for security groups firewall in the L2 agent (string value)
+#firewall_driver = <None>
+
+# Controls whether the neutron security group API is enabled in the server. It
+# should be false when using no security groups or using the nova security
+# group API. (boolean value)
+#enable_security_group = true
+
+# Use ipset to speed-up the iptables based security groups. Enabling ipset
+# support requires that ipset is installed on L2 agent node. (boolean value)
+#enable_ipset = true
+
+
+[vxlan]
+enable_vxlan = True
+local_ip = OVERLAY_INTERFACE_IP_ADDRESS
+l2_population = True
+
+#
+# From neutron.ml2.linuxbridge.agent
+#
+
+# Enable VXLAN on the agent. Can be enabled when agent is managed by ml2 plugin
+# using linuxbridge mechanism driver (boolean value)
+#enable_vxlan = true
+
+# TTL for vxlan interface protocol packets. (integer value)
+#ttl = <None>
+
+# TOS for vxlan interface protocol packets. (integer value)
+#tos = <None>
+
+# Multicast group(s) for vxlan interface. A range of group addresses may be
+# specified by using CIDR notation. Specifying a range allows different VNIs to
+# use different group addresses, reducing or eliminating spurious broadcast
+# traffic to the tunnel endpoints. To reserve a unique group for each possible
+# (24-bit) VNI, use a /8 such as 239.0.0.0/8. This setting must be the same on
+# all the agents. (string value)
+#vxlan_group = 224.0.0.1
+
+# Local IP address of the VXLAN endpoints. (IP address value)
+#local_ip = <None>
+
+# Extension to use alongside ml2 plugin's l2population mechanism driver. It
+# enables the plugin to populate VXLAN forwarding table. (boolean value)
+#l2_population = false
+
+# Enable local ARP responder which provides local responses instead of
+# performing ARP broadcast into the overlay. Enabling local ARP responder is
+# not fullycompatible with the allowed-address-pairs extension. (boolean value)
+#arp_responder = false

--- a/rocky/local_settings.py
+++ b/rocky/local_settings.py
@@ -1,0 +1,745 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+from django.utils.translation import ugettext_lazy as _
+
+from horizon.utils import secret_key
+
+from openstack_dashboard import exceptions
+from openstack_dashboard.settings import HORIZON_CONFIG
+
+DEBUG = False
+TEMPLATE_DEBUG = DEBUG
+
+
+# WEBROOT is the location relative to Webserver root
+# should end with a slash.
+WEBROOT = '/'
+#LOGIN_URL = WEBROOT + 'auth/login/'
+#LOGOUT_URL = WEBROOT + 'auth/logout/'
+#
+# LOGIN_REDIRECT_URL can be used as an alternative for
+# HORIZON_CONFIG.user_home, if user_home is not set.
+# Do not set it to '/home/', as this will cause circular redirect loop
+#LOGIN_REDIRECT_URL = WEBROOT
+
+# If horizon is running in production (DEBUG is False), set this
+# with the list of host/domain names that the application can serve.
+# For more information see:
+# https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
+#ALLOWED_HOSTS = ['horizon.example.com', ]
+
+# Set SSL proxy settings:
+# Pass this header from the proxy after terminating the SSL,
+# and don't forget to strip it from the client's request.
+# For more information see:
+# https://docs.djangoproject.com/en/1.8/ref/settings/#secure-proxy-ssl-header
+#SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+# If Horizon is being served through SSL, then uncomment the following two
+# settings to better secure the cookies from security exploits
+#CSRF_COOKIE_SECURE = True
+#SESSION_COOKIE_SECURE = True
+
+# The absolute path to the directory where message files are collected.
+# The message file must have a .json file extension. When the user logins to
+# horizon, the message files collected are processed and displayed to the user.
+#MESSAGES_PATH=None
+
+# Overrides for OpenStack API versions. Use this setting to force the
+# OpenStack dashboard to use a specific API version for a given service API.
+# Versions specified here should be integers or floats, not strings.
+# NOTE: The version should be formatted as it appears in the URL for the
+# service API. For example, The identity service APIs have inconsistent
+# use of the decimal point, so valid options would be 2.0 or 3.
+OPENSTACK_API_VERSIONS = {
+    "identity": 3,
+    "image": 2,
+    "volume": 2,
+#    "data-processing": 1.1,
+#    "compute": 2,
+}
+
+# Set this to True if running on multi-domain model. When this is enabled, it
+# will require user to enter the Domain name in addition to username for login.
+OPENSTACK_KEYSTONE_MULTIDOMAIN_SUPPORT = True
+
+# Overrides the default domain used when running on single-domain model
+# with Keystone V3. All entities will be created in the default domain.
+# NOTE: This value must be the ID of the default domain, NOT the name.
+# Also, you will most likely have a value in the keystone policy file like this
+#    "cloud_admin": "rule:admin_required and domain_id:<your domain id>"
+# This value must match the domain id specified there.
+OPENSTACK_KEYSTONE_DEFAULT_DOMAIN = 'Default'
+
+# Set this to True to enable panels that provide the ability for users to
+# manage Identity Providers (IdPs) and establish a set of rules to map
+# federation protocol attributes to Identity API attributes.
+# This extension requires v3.0+ of the Identity API.
+#OPENSTACK_KEYSTONE_FEDERATION_MANAGEMENT = False
+
+# Set Console type:
+# valid options are "AUTO"(default), "VNC", "SPICE", "RDP", "SERIAL" or None
+# Set to None explicitly if you want to deactivate the console.
+#CONSOLE_TYPE = "AUTO"
+
+# If provided, a "Report Bug" link will be displayed in the site header
+# which links to the value of this setting (ideally a URL containing
+# information on how to report issues).
+#HORIZON_CONFIG["bug_url"] = "http://bug-report.example.com"
+
+# Show backdrop element outside the modal, do not close the modal
+# after clicking on backdrop.
+#HORIZON_CONFIG["modal_backdrop"] = "static"
+
+# Specify a regular expression to validate user passwords.
+#HORIZON_CONFIG["password_validator"] = {
+#    "regex": '.*',
+#    "help_text": _("Your password does not meet the requirements."),
+#}
+
+# Disable simplified floating IP address management for deployments with
+# multiple floating IP pools or complex network requirements.
+#HORIZON_CONFIG["simple_ip_management"] = False
+
+# Turn off browser autocompletion for forms including the login form and
+# the database creation workflow if so desired.
+#HORIZON_CONFIG["password_autocomplete"] = "off"
+
+# Setting this to True will disable the reveal button for password fields,
+# including on the login form.
+#HORIZON_CONFIG["disable_password_reveal"] = False
+
+LOCAL_PATH = os.path.dirname(os.path.abspath(__file__))
+
+# Set custom secret key:
+# You can either set it to a specific value or you can let horizon generate a
+# default secret key that is unique on this machine, e.i. regardless of the
+# amount of Python WSGI workers (if used behind Apache+mod_wsgi): However,
+# there may be situations where you would want to set this explicitly, e.g.
+# when multiple dashboard instances are distributed on different machines
+# (usually behind a load-balancer). Either you have to make sure that a session
+# gets all requests routed to the same dashboard instance or you set the same
+# SECRET_KEY for all of them.
+SECRET_KEY = secret_key.generate_or_read_from_file('/var/lib/openstack-dashboard/secret_key')
+
+# We recommend you use memcached for development; otherwise after every reload
+# of the django development server, you will have to login again. To use
+# memcached set CACHES to something like
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+    },
+}
+
+#CACHES = {
+#    'default': {
+#        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+#    }
+#}
+
+# Send email to the console by default
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# Or send them to /dev/null
+#EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+
+# Configure these for your outgoing email host
+#EMAIL_HOST = 'smtp.my-company.com'
+#EMAIL_PORT = 25
+#EMAIL_HOST_USER = 'djangomail'
+#EMAIL_HOST_PASSWORD = 'top-secret!'
+
+# For multiple regions uncomment this configuration, and add (endpoint, title).
+#AVAILABLE_REGIONS = [
+#    ('http://cluster1.example.com:5000/v2.0', 'cluster1'),
+#    ('http://cluster2.example.com:5000/v2.0', 'cluster2'),
+#]
+
+OPENSTACK_HOST = "127.0.0.1"
+OPENSTACK_KEYSTONE_URL = "http://%s:5000/v3" % OPENSTACK_HOST
+OPENSTACK_KEYSTONE_DEFAULT_ROLE = "user"
+
+# Enables keystone web single-sign-on if set to True.
+#WEBSSO_ENABLED = False
+
+# Determines which authentication choice to show as default.
+#WEBSSO_INITIAL_CHOICE = "credentials"
+
+# The list of authentication mechanisms which include keystone
+# federation protocols and identity provider/federation protocol
+# mapping keys (WEBSSO_IDP_MAPPING). Current supported protocol
+# IDs are 'saml2' and 'oidc'  which represent SAML 2.0, OpenID
+# Connect respectively.
+# Do not remove the mandatory credentials mechanism.
+# Note: The last two tuples are sample mapping keys to a identity provider
+# and federation protocol combination (WEBSSO_IDP_MAPPING).
+#WEBSSO_CHOICES = (
+#    ("credentials", _("Keystone Credentials")),
+#    ("oidc", _("OpenID Connect")),
+#    ("saml2", _("Security Assertion Markup Language")),
+#    ("acme_oidc", "ACME - OpenID Connect"),
+#    ("acme_saml2", "ACME - SAML2"),
+#)
+
+# A dictionary of specific identity provider and federation protocol
+# combinations. From the selected authentication mechanism, the value
+# will be looked up as keys in the dictionary. If a match is found,
+# it will redirect the user to a identity provider and federation protocol
+# specific WebSSO endpoint in keystone, otherwise it will use the value
+# as the protocol_id when redirecting to the WebSSO by protocol endpoint.
+# NOTE: The value is expected to be a tuple formatted as: (<idp_id>, <protocol_id>).
+#WEBSSO_IDP_MAPPING = {
+#    "acme_oidc": ("acme", "oidc"),
+#    "acme_saml2": ("acme", "saml2"),
+#}
+
+# Disable SSL certificate checks (useful for self-signed certificates):
+#OPENSTACK_SSL_NO_VERIFY = True
+
+# The CA certificate to use to verify SSL connections
+#OPENSTACK_SSL_CACERT = '/path/to/cacert.pem'
+
+# The OPENSTACK_KEYSTONE_BACKEND settings can be used to identify the
+# capabilities of the auth backend for Keystone.
+# If Keystone has been configured to use LDAP as the auth backend then set
+# can_edit_user to False and name to 'ldap'.
+#
+# TODO(tres): Remove these once Keystone has an API to identify auth backend.
+OPENSTACK_KEYSTONE_BACKEND = {
+    'name': 'native',
+    'can_edit_user': True,
+    'can_edit_group': True,
+    'can_edit_project': True,
+    'can_edit_domain': True,
+    'can_edit_role': True,
+}
+
+# Setting this to True, will add a new "Retrieve Password" action on instance,
+# allowing Admin session password retrieval/decryption.
+#OPENSTACK_ENABLE_PASSWORD_RETRIEVE = False
+
+# The Launch Instance user experience has been significantly enhanced.
+# You can choose whether to enable the new launch instance experience,
+# the legacy experience, or both. The legacy experience will be removed
+# in a future release, but is available as a temporary backup setting to ensure
+# compatibility with existing deployments. Further development will not be
+# done on the legacy experience. Please report any problems with the new
+# experience via the Launchpad tracking system.
+#
+# Toggle LAUNCH_INSTANCE_LEGACY_ENABLED and LAUNCH_INSTANCE_NG_ENABLED to
+# determine the experience to enable.  Set them both to true to enable
+# both.
+#LAUNCH_INSTANCE_LEGACY_ENABLED = True
+#LAUNCH_INSTANCE_NG_ENABLED = False
+
+# A dictionary of settings which can be used to provide the default values for
+# properties found in the Launch Instance modal.
+#LAUNCH_INSTANCE_DEFAULTS = {
+#    'config_drive': False,
+#}
+
+# The Xen Hypervisor has the ability to set the mount point for volumes
+# attached to instances (other Hypervisors currently do not). Setting
+# can_set_mount_point to True will add the option to set the mount point
+# from the UI.
+OPENSTACK_HYPERVISOR_FEATURES = {
+    'can_set_mount_point': False,
+    'can_set_password': False,
+    'requires_keypair': False,
+}
+
+# The OPENSTACK_CINDER_FEATURES settings can be used to enable optional
+# services provided by cinder that is not exposed by its extension API.
+OPENSTACK_CINDER_FEATURES = {
+    'enable_backup': False,
+}
+
+# The OPENSTACK_NEUTRON_NETWORK settings can be used to enable optional
+# services provided by neutron. Options currently available are load
+# balancer service, security groups, quotas, VPN service.
+OPENSTACK_NEUTRON_NETWORK = {
+    'enable_router': True,
+    'enable_quotas': True,
+    'enable_ipv6': True,
+    'enable_distributed_router': False,
+    'enable_ha_router': False,
+    'enable_lb': True,
+    'enable_firewall': True,
+    'enable_vpn': True,
+    'enable_fip_topology_check': True,
+
+    # Neutron can be configured with a default Subnet Pool to be used for IPv4
+    # subnet-allocation. Specify the label you wish to display in the Address
+    # pool selector on the create subnet step if you want to use this feature.
+    'default_ipv4_subnet_pool_label': None,
+
+    # Neutron can be configured with a default Subnet Pool to be used for IPv6
+    # subnet-allocation. Specify the label you wish to display in the Address
+    # pool selector on the create subnet step if you want to use this feature.
+    # You must set this to enable IPv6 Prefix Delegation in a PD-capable
+    # environment.
+    'default_ipv6_subnet_pool_label': None,
+
+    # The profile_support option is used to detect if an external router can be
+    # configured via the dashboard. When using specific plugins the
+    # profile_support can be turned on if needed.
+    'profile_support': None,
+    #'profile_support': 'cisco',
+
+    # Set which provider network types are supported. Only the network types
+    # in this list will be available to choose from when creating a network.
+    # Network types include local, flat, vlan, gre, and vxlan.
+    'supported_provider_types': ['*'],
+
+    # Set which VNIC types are supported for port binding. Only the VNIC
+    # types in this list will be available to choose from when creating a
+    # port.
+    # VNIC types include 'normal', 'macvtap' and 'direct'.
+    # Set to empty list or None to disable VNIC type selection.
+    'supported_vnic_types': ['*'],
+}
+
+# The OPENSTACK_HEAT_STACK settings can be used to disable password
+# field required while launching the stack.
+OPENSTACK_HEAT_STACK = {
+    'enable_user_pass': True,
+}
+
+# The OPENSTACK_IMAGE_BACKEND settings can be used to customize features
+# in the OpenStack Dashboard related to the Image service, such as the list
+# of supported image formats.
+#OPENSTACK_IMAGE_BACKEND = {
+#    'image_formats': [
+#        ('', _('Select format')),
+#        ('aki', _('AKI - Amazon Kernel Image')),
+#        ('ami', _('AMI - Amazon Machine Image')),
+#        ('ari', _('ARI - Amazon Ramdisk Image')),
+#        ('docker', _('Docker')),
+#        ('iso', _('ISO - Optical Disk Image')),
+#        ('ova', _('OVA - Open Virtual Appliance')),
+#        ('qcow2', _('QCOW2 - QEMU Emulator')),
+#        ('raw', _('Raw')),
+#        ('vdi', _('VDI - Virtual Disk Image')),
+#        ('vhd', _('VHD - Virtual Hard Disk')),
+#        ('vmdk', _('VMDK - Virtual Machine Disk')),
+#    ],
+#}
+
+# The IMAGE_CUSTOM_PROPERTY_TITLES settings is used to customize the titles for
+# image custom property attributes that appear on image detail pages.
+IMAGE_CUSTOM_PROPERTY_TITLES = {
+    "architecture": _("Architecture"),
+    "kernel_id": _("Kernel ID"),
+    "ramdisk_id": _("Ramdisk ID"),
+    "image_state": _("Euca2ools state"),
+    "project_id": _("Project ID"),
+    "image_type": _("Image Type"),
+}
+
+# The IMAGE_RESERVED_CUSTOM_PROPERTIES setting is used to specify which image
+# custom properties should not be displayed in the Image Custom Properties
+# table.
+IMAGE_RESERVED_CUSTOM_PROPERTIES = []
+
+# OPENSTACK_ENDPOINT_TYPE specifies the endpoint type to use for the endpoints
+# in the Keystone service catalog. Use this setting when Horizon is running
+# external to the OpenStack environment. The default is 'publicURL'.
+#OPENSTACK_ENDPOINT_TYPE = "publicURL"
+
+# SECONDARY_ENDPOINT_TYPE specifies the fallback endpoint type to use in the
+# case that OPENSTACK_ENDPOINT_TYPE is not present in the endpoints
+# in the Keystone service catalog. Use this setting when Horizon is running
+# external to the OpenStack environment. The default is None.  This
+# value should differ from OPENSTACK_ENDPOINT_TYPE if used.
+#SECONDARY_ENDPOINT_TYPE = "publicURL"
+
+# The number of objects (Swift containers/objects or images) to display
+# on a single page before providing a paging element (a "more" link)
+# to paginate results.
+API_RESULT_LIMIT = 1000
+API_RESULT_PAGE_SIZE = 20
+
+# The size of chunk in bytes for downloading objects from Swift
+SWIFT_FILE_TRANSFER_CHUNK_SIZE = 512 * 1024
+
+# Specify a maximum number of items to display in a dropdown.
+DROPDOWN_MAX_ITEMS = 30
+
+# The timezone of the server. This should correspond with the timezone
+# of your entire OpenStack installation, and hopefully be in UTC.
+TIME_ZONE = "UTC"
+
+# When launching an instance, the menu of available flavors is
+# sorted by RAM usage, ascending. If you would like a different sort order,
+# you can provide another flavor attribute as sorting key. Alternatively, you
+# can provide a custom callback method to use for sorting. You can also provide
+# a flag for reverse sort. For more info, see
+# http://docs.python.org/2/library/functions.html#sorted
+#CREATE_INSTANCE_FLAVOR_SORT = {
+#    'key': 'name',
+#     # or
+#    'key': my_awesome_callback_method,
+#    'reverse': False,
+#}
+
+# Set this to True to display an 'Admin Password' field on the Change Password
+# form to verify that it is indeed the admin logged-in who wants to change
+# the password.
+#ENFORCE_PASSWORD_CHECK = False
+
+# Modules that provide /auth routes that can be used to handle different types
+# of user authentication. Add auth plugins that require extra route handling to
+# this list.
+#AUTHENTICATION_URLS = [
+#    'openstack_auth.urls',
+#]
+
+# The Horizon Policy Enforcement engine uses these values to load per service
+# policy rule files. The content of these files should match the files the
+# OpenStack services are using to determine role based access control in the
+# target installation.
+
+# Path to directory containing policy.json files
+#POLICY_FILES_PATH = os.path.join(ROOT_PATH, "conf")
+
+# Map of local copy of service policy files.
+# Please insure that your identity policy file matches the one being used on
+# your keystone servers. There is an alternate policy file that may be used
+# in the Keystone v3 multi-domain case, policy.v3cloudsample.json.
+# This file is not included in the Horizon repository by default but can be
+# found at
+# http://git.openstack.org/cgit/openstack/keystone/tree/etc/ \
+# policy.v3cloudsample.json
+# Having matching policy files on the Horizon and Keystone servers is essential
+# for normal operation. This holds true for all services and their policy files.
+#POLICY_FILES = {
+#    'identity': 'keystone_policy.json',
+#    'compute': 'nova_policy.json',
+#    'volume': 'cinder_policy.json',
+#    'image': 'glance_policy.json',
+#    'orchestration': 'heat_policy.json',
+#    'network': 'neutron_policy.json',
+#    'telemetry': 'ceilometer_policy.json',
+#}
+
+# TODO: (david-lyle) remove when plugins support adding settings.
+# Note: Only used when trove-dashboard plugin is configured to be used by
+# Horizon.
+# Trove user and database extension support. By default support for
+# creating users and databases on database instances is turned on.
+# To disable these extensions set the permission here to something
+# unusable such as ["!"].
+#TROVE_ADD_USER_PERMS = []
+#TROVE_ADD_DATABASE_PERMS = []
+
+# Change this patch to the appropriate list of tuples containing
+# a key, label and static directory containing two files:
+# _variables.scss and _styles.scss
+#AVAILABLE_THEMES = [
+#    ('default', 'Default', 'themes/default'),
+#    ('material', 'Material', 'themes/material'),
+#]
+
+LOGGING = {
+    'version': 1,
+    # When set to True this will disable all logging except
+    # for loggers specified in this configuration dictionary. Note that
+    # if nothing is specified here and disable_existing_loggers is True,
+    # django.db.backends will still log unless it is disabled explicitly.
+    'disable_existing_loggers': False,
+    'handlers': {
+        'null': {
+            'level': 'DEBUG',
+            'class': 'logging.NullHandler',
+        },
+        'console': {
+            # Set the level to "DEBUG" for verbose output logging.
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        # Logging from django.db.backends is VERY verbose, send to null
+        # by default.
+        'django.db.backends': {
+            'handlers': ['null'],
+            'propagate': False,
+        },
+        'requests': {
+            'handlers': ['null'],
+            'propagate': False,
+        },
+        'horizon': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'openstack_dashboard': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'novaclient': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'cinderclient': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'keystoneclient': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'glanceclient': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'neutronclient': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'heatclient': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'ceilometerclient': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'swiftclient': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'openstack_auth': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'nose.plugins.manager': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'django': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'iso8601': {
+            'handlers': ['null'],
+            'propagate': False,
+        },
+        'scss': {
+            'handlers': ['null'],
+            'propagate': False,
+        },
+    },
+}
+
+# 'direction' should not be specified for all_tcp/udp/icmp.
+# It is specified in the form.
+SECURITY_GROUP_RULES = {
+    'all_tcp': {
+        'name': _('All TCP'),
+        'ip_protocol': 'tcp',
+        'from_port': '1',
+        'to_port': '65535',
+    },
+    'all_udp': {
+        'name': _('All UDP'),
+        'ip_protocol': 'udp',
+        'from_port': '1',
+        'to_port': '65535',
+    },
+    'all_icmp': {
+        'name': _('All ICMP'),
+        'ip_protocol': 'icmp',
+        'from_port': '-1',
+        'to_port': '-1',
+    },
+    'ssh': {
+        'name': 'SSH',
+        'ip_protocol': 'tcp',
+        'from_port': '22',
+        'to_port': '22',
+    },
+    'smtp': {
+        'name': 'SMTP',
+        'ip_protocol': 'tcp',
+        'from_port': '25',
+        'to_port': '25',
+    },
+    'dns': {
+        'name': 'DNS',
+        'ip_protocol': 'tcp',
+        'from_port': '53',
+        'to_port': '53',
+    },
+    'http': {
+        'name': 'HTTP',
+        'ip_protocol': 'tcp',
+        'from_port': '80',
+        'to_port': '80',
+    },
+    'pop3': {
+        'name': 'POP3',
+        'ip_protocol': 'tcp',
+        'from_port': '110',
+        'to_port': '110',
+    },
+    'imap': {
+        'name': 'IMAP',
+        'ip_protocol': 'tcp',
+        'from_port': '143',
+        'to_port': '143',
+    },
+    'ldap': {
+        'name': 'LDAP',
+        'ip_protocol': 'tcp',
+        'from_port': '389',
+        'to_port': '389',
+    },
+    'https': {
+        'name': 'HTTPS',
+        'ip_protocol': 'tcp',
+        'from_port': '443',
+        'to_port': '443',
+    },
+    'smtps': {
+        'name': 'SMTPS',
+        'ip_protocol': 'tcp',
+        'from_port': '465',
+        'to_port': '465',
+    },
+    'imaps': {
+        'name': 'IMAPS',
+        'ip_protocol': 'tcp',
+        'from_port': '993',
+        'to_port': '993',
+    },
+    'pop3s': {
+        'name': 'POP3S',
+        'ip_protocol': 'tcp',
+        'from_port': '995',
+        'to_port': '995',
+    },
+    'ms_sql': {
+        'name': 'MS SQL',
+        'ip_protocol': 'tcp',
+        'from_port': '1433',
+        'to_port': '1433',
+    },
+    'mysql': {
+        'name': 'MYSQL',
+        'ip_protocol': 'tcp',
+        'from_port': '3306',
+        'to_port': '3306',
+    },
+    'rdp': {
+        'name': 'RDP',
+        'ip_protocol': 'tcp',
+        'from_port': '3389',
+        'to_port': '3389',
+    },
+}
+
+# Deprecation Notice:
+#
+# The setting FLAVOR_EXTRA_KEYS has been deprecated.
+# Please load extra spec metadata into the Glance Metadata Definition Catalog.
+#
+# The sample quota definitions can be found in:
+# <glance_source>/etc/metadefs/compute-quota.json
+#
+# The metadata definition catalog supports CLI and API:
+#  $glance --os-image-api-version 2 help md-namespace-import
+#  $glance-manage db_load_metadefs <directory_with_definition_files>
+#
+# See Metadata Definitions on: http://docs.openstack.org/developer/glance/
+
+# TODO: (david-lyle) remove when plugins support settings natively
+# Note: This is only used when the Sahara plugin is configured and enabled
+# for use in Horizon.
+# Indicate to the Sahara data processing service whether or not
+# automatic floating IP allocation is in effect.  If it is not
+# in effect, the user will be prompted to choose a floating IP
+# pool for use in their cluster.  False by default.  You would want
+# to set this to True if you were running Nova Networking with
+# auto_assign_floating_ip = True.
+#SAHARA_AUTO_IP_ALLOCATION_ENABLED = False
+
+# The hash algorithm to use for authentication tokens. This must
+# match the hash algorithm that the identity server and the
+# auth_token middleware are using. Allowed values are the
+# algorithms supported by Python's hashlib library.
+#OPENSTACK_TOKEN_HASH_ALGORITHM = 'md5'
+
+# Hashing tokens from Keystone keeps the Horizon session data smaller, but it
+# doesn't work in some cases when using PKI tokens.  Uncomment this value and
+# set it to False if using PKI tokens and there are 401 errors due to token
+# hashing.
+#OPENSTACK_TOKEN_HASH_ENABLED = True
+
+# AngularJS requires some settings to be made available to
+# the client side. Some settings are required by in-tree / built-in horizon
+# features. These settings must be added to REST_API_REQUIRED_SETTINGS in the
+# form of ['SETTING_1','SETTING_2'], etc.
+#
+# You may remove settings from this list for security purposes, but do so at
+# the risk of breaking a built-in horizon feature. These settings are required
+# for horizon to function properly. Only remove them if you know what you
+# are doing. These settings may in the future be moved to be defined within
+# the enabled panel configuration.
+# You should not add settings to this list for out of tree extensions.
+# See: https://wiki.openstack.org/wiki/Horizon/RESTAPI
+REST_API_REQUIRED_SETTINGS = ['OPENSTACK_HYPERVISOR_FEATURES',
+                              'LAUNCH_INSTANCE_DEFAULTS']
+
+# Additional settings can be made available to the client side for
+# extensibility by specifying them in REST_API_ADDITIONAL_SETTINGS
+# !! Please use extreme caution as the settings are transferred via HTTP/S
+# and are not encrypted on the browser. This is an experimental API and
+# may be deprecated in the future without notice.
+#REST_API_ADDITIONAL_SETTINGS = []
+
+###############################################################################
+# Ubuntu Settings
+###############################################################################
+
+# Enable the Ubuntu theme if it is present.
+try:
+  from ubuntu_theme import *
+except ImportError:
+  pass
+
+# Default Ubuntu apache configuration uses /horizon as the application root.
+WEBROOT='/horizon/'
+
+# By default, validation of the HTTP Host header is disabled.  Production
+# installations should have this set accordingly.  For more information
+# see https://docs.djangoproject.com/en/dev/ref/settings/.
+ALLOWED_HOSTS = ['*',]
+
+# Compress all assets offline as part of packaging installation
+COMPRESS_OFFLINE = True
+
+# DISALLOW_IFRAME_EMBED can be used to prevent Horizon from being embedded
+# within an iframe. Legacy browsers are still vulnerable to a Cross-Frame
+# Scripting (XFS) vulnerability, so this option allows extra security hardening
+# where iframes are not used in deployment. Default setting is True.
+# For more information see:
+# http://tinyurl.com/anticlickjack
+#DISALLOW_IFRAME_EMBED = True

--- a/rocky/metadata_agent.ini
+++ b/rocky/metadata_agent.ini
@@ -1,0 +1,180 @@
+[DEFAULT]
+nova_metadata_ip = localhost
+metadata_proxy_shared_secret = avi123
+
+#
+# From neutron.metadata.agent
+#
+
+# Location for Metadata Proxy UNIX domain socket. (string value)
+#metadata_proxy_socket = $state_path/metadata_proxy
+
+# User (uid or name) running metadata proxy after its initialization (if empty:
+# agent effective user). (string value)
+#metadata_proxy_user =
+
+# Group (gid or name) running metadata proxy after its initialization (if
+# empty: agent effective group). (string value)
+#metadata_proxy_group =
+
+# Certificate Authority public key (CA cert) file for ssl (string value)
+#auth_ca_cert = <None>
+
+# IP address used by Nova metadata server. (string value)
+#nova_metadata_ip = 127.0.0.1
+
+# TCP Port used by Nova metadata server. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#nova_metadata_port = 8775
+
+# When proxying metadata requests, Neutron signs the Instance-ID header with a
+# shared secret to prevent spoofing. You may select any string for a secret,
+# but it must match here and in the configuration used by the Nova Metadata
+# Server. NOTE: Nova uses the same config key, but in [neutron] section.
+# (string value)
+#metadata_proxy_shared_secret =
+
+# Protocol to access nova metadata, http or https (string value)
+# Allowed values: http, https
+#nova_metadata_protocol = http
+
+# Allow to perform insecure SSL (https) requests to nova metadata (boolean
+# value)
+#nova_metadata_insecure = false
+
+# Client certificate for nova metadata api server. (string value)
+#nova_client_cert =
+
+# Private key of client certificate. (string value)
+#nova_client_priv_key =
+
+# Metadata Proxy UNIX domain socket mode, 4 values allowed: 'deduce': deduce
+# mode from metadata_proxy_user/group values, 'user': set metadata proxy socket
+# mode to 0o644, to use when metadata_proxy_user is agent effective user or
+# root, 'group': set metadata proxy socket mode to 0o664, to use when
+# metadata_proxy_group is agent effective group or root, 'all': set metadata
+# proxy socket mode to 0o666, to use otherwise. (string value)
+# Allowed values: deduce, user, group, all
+#metadata_proxy_socket_mode = deduce
+
+# Number of separate worker processes for metadata server (defaults to half of
+# the number of CPUs) (integer value)
+#metadata_workers = 2
+
+# Number of backlog requests to configure the metadata server socket with
+# (integer value)
+#metadata_backlog = 4096
+
+# URL to connect to the cache back end. (string value)
+#cache_url = memory://
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of the default
+# INFO level. (boolean value)
+#debug = false
+
+# If set to false, the logging level will be set to WARNING instead of the
+# default INFO level. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#verbose = true
+
+# The name of a logging configuration file. This file is appended to any
+# existing logging configuration files. For details about logging configuration
+# files, see the Python logging module documentation. Note that when logging
+# configuration files are used then all logging configuration is set in the
+# configuration file and other logging configuration options are ignored (for
+# example, logging_context_format_string). (string value)
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set. (string
+# value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default is set,
+# logging will go to stderr as defined by use_stderr. This option is ignored if
+# log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths. This option
+# is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is moved or
+# removed this handler will open a new log file with specified path
+# instantaneously. It makes sense only if log_file option is specified and
+# Linux platform is used. This option is ignored if log_config_append is set.
+# (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and will be
+# changed later to honor RFC5424. This option is ignored if log_config_append
+# is set. (boolean value)
+#use_syslog = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Log output to standard error. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_stderr = true
+
+# Format string to use for log messages with context. (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined. (string
+# value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the message
+# is DEBUG. (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. (string value)
+#logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is ignored
+# if log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,dogpile.core.dogpile=INFO
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message. (string
+# value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message. (string
+# value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false
+
+
+[AGENT]
+
+#
+# From neutron.metadata.agent
+#
+
+# Seconds between nodes reporting state to server; should be less than
+# agent_down_time, best if it is half or less than agent_down_time. (floating
+# point value)
+#report_interval = 30
+
+# Log agent heartbeats (boolean value)
+#log_agent_heartbeats = false

--- a/rocky/ml2_conf.ini
+++ b/rocky/ml2_conf.ini
@@ -1,0 +1,14 @@
+[ml2]
+type_drivers = flat,vlan,vxlan
+tenant_network_types = vxlan
+mechanism_drivers = linuxbridge,l2population
+extension_drivers = port_security
+[ml2_type_flat]
+flat_networks = provider
+[ml2_type_vlan]
+[ml2_type_gre]
+[ml2_type_vxlan]
+vni_ranges = 1:1000
+[ml2_type_geneve]
+[securitygroup]
+enable_ipset = True

--- a/rocky/mysqld_openstack.cnf
+++ b/rocky/mysqld_openstack.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+bind-address = *
+default-storage-engine = innodb
+innodb_file_per_table = on
+max_connections = 4096
+collation-server = utf8_general_ci
+character-set-server = utf8

--- a/rocky/neutron.conf
+++ b/rocky/neutron.conf
@@ -1,0 +1,47 @@
+[DEFAULT]
+core_plugin = ml2
+service_plugins = router
+allow_overlapping_ips = True
+transport_url=rabbit://openstack:avi123@localhost
+auth_strategy = keystone
+notify_nova_on_port_status_changes = true
+notify_nova_on_port_data_changes = true
+[agent]
+root_helper = sudo /usr/bin/neutron-rootwrap /etc/neutron/rootwrap.conf
+[cors]
+[cors.subdomain]
+[database]
+connection = mysql+pymysql://neutron:avi123@localhost/neutron
+[keystone_authtoken]
+auth_uri = http://localhost:5000
+auth_url = http://localhost:5000
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = neutron
+password = avi123
+[matchmaker_redis]
+[nova]
+auth_url = http://localhost:5000
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+region_name = RegionOne
+project_name = service
+username = nova
+password = avi123
+[oslo_concurrency]
+lock_path = /var/log/neutron
+[oslo_messaging_amqp]
+[oslo_messaging_kafka]
+[oslo_messaging_notifications]
+[oslo_messaging_rabbit]
+[oslo_messaging_zmq]
+[oslo_middleware]
+[oslo_policy]
+[qos]
+[quotas]
+[ssl]
+

--- a/rocky/nova.conf
+++ b/rocky/nova.conf
@@ -1,0 +1,150 @@
+[DEFAULT]
+dhcpbridge_flagfile=/etc/nova/nova.conf
+dhcpbridge=/usr/bin/nova-dhcpbridge
+force_dhcp_release=true
+state_path=/var/lib/nova
+enabled_apis=osapi_compute,metadata
+[barbican]
+[cache]
+[cells]
+enable=False
+[cinder]
+[cloudpipe]
+[conductor]
+[console]
+[consoleauth]
+[cors]
+[cors.subdomain]
+[crypto]
+[database]
+[ephemeral_storage_encryption]
+[filter_scheduler]
+[glance]
+[guestfs]
+[healthcheck]
+[hyperv]
+[image_file_url]
+[ironic]
+[key_manager]
+[keystone_authtoken]
+[libvirt]
+[matchmaker_redis]
+[metrics]
+[mks]
+[neutron]
+[notifications]
+[osapi_v21]
+[oslo_concurrency]
+lock_path=/var/lock/nova
+[oslo_messaging_amqp]
+[oslo_messaging_kafka]
+[oslo_messaging_notifications]
+[oslo_messaging_rabbit]
+[oslo_messaging_zmq]
+[oslo_middleware]
+[oslo_policy]
+[pci]
+[quota]
+[rdp]
+[remote_debug]
+[scheduler]
+[serial_console]
+[service_user]
+[spice]
+[ssl]
+[trusted_computing]
+[upgrade_levels]
+[vendordata_dynamic_auth]
+[vmware]
+[workarounds]
+[wsgi]
+api_paste_config=/etc/nova/api-paste.ini
+[xenserver]
+[xvp]
+[DEFAULT]
+dhcpbridge_flagfile=/etc/nova/nova.conf
+dhcpbridge=/usr/bin/nova-dhcpbridge
+logdir=/var/log/nova
+state_path=/var/lib/nova
+lock_path=/var/lock/nova
+force_dhcp_release=True
+libvirt_use_virtio_for_bridges=True
+verbose=True
+ec2_private_dns_show_ip=True
+api_paste_config=/etc/nova/api-paste.ini
+enabled_apis=osapi_compute
+
+my_ip = MY_IP
+
+rpc_backend = rabbit
+auth_strategy = keystone
+
+network_api_class = nova.network.neutronv2.api.API
+security_group_api = neutron
+linuxnet_interface_driver = nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver
+firewall_driver = nova.virt.firewall.NoopFirewallDriver
+transport_url = rabbit://openstack:avi123@localhost
+use_neutron = True
+
+[vnc]
+enabled = true
+vncserver_listen = 0.0.0.0
+vncserver_proxyclient_address = $my_ip
+novncproxy_base_url = http://$my_ip:6080/vnc_auto.html
+
+[database]
+connection = mysql+pymysql://nova:avi123@localhost/nova
+
+[api_database]
+connection = mysql+pymysql://nova:avi123@localhost/nova_api
+
+[api]
+auth_strategy = keystone
+
+[oslo_messaging_rabbit]
+rabbit_host = localhost
+rabbit_userid = openstack
+rabbit_password = avi123
+
+
+[keystone_authtoken]
+auth_uri = http://localhost:5000
+auth_url = http://localhost:5000
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = nova
+password = avi123
+
+
+[oslo_concurrency]
+lock_path = /var/lib/nova/tmp
+
+[glance]
+api_servers = http://localhost:9292
+
+[placement]
+os_region_name = RegionOne
+project_domain_name = Default
+project_name = service
+auth_type = password
+user_domain_name = Default
+auth_url = http://localhost:5000/v3
+username = placement
+password = avi123
+
+[neutron]
+url = http://localhost:9696
+auth_url = http://localhost:5000
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+region_name = RegionOne
+project_name = service
+username = neutron
+password = avi123
+
+service_metadata_proxy = True
+metadata_proxy_shared_secret = avi123

--- a/rocky/post-install.sh
+++ b/rocky/post-install.sh
@@ -1,0 +1,18 @@
+set -e
+set -x
+
+
+# for floating IP and external connectivity
+# choose a small pool from the subnet from ens4
+POOL_START=
+POOL_END=
+GW=
+CIDR=
+
+source /root/admin-openrc.sh
+neutron net-create --shared --router:external --provider:physical_network provider --provider:network_type flat provider1
+neutron subnet-create --name provider1-v4 --ip-version 4 \
+   --allocation-pool start=$POOL_START,end=$POOL_END \
+   --gateway $GW --dns-nameserver 8.8.4.4 provider1 \
+   $CIDR 
+

--- a/rocky/router-aap.sh
+++ b/rocky/router-aap.sh
@@ -1,0 +1,33 @@
+set -x
+set -e
+interface="ens4"
+cidr="10.90.0.0/16"
+
+my_mac=`ifconfig $interface | grep "ether" | awk '{print $2;}'`
+if [ -z "$my_mac" ]; then
+    echo "Can't find mac!"
+    exit
+fi
+
+# Resolve openstack-controller
+sed -i "/nameserver/d" /etc/resolv.conf
+sed -i "/search/d" /etc/resolv.conf
+echo "nameserver 10.10.0.100" >> /etc/resolv.conf
+echo "search avi.local" >> /etc/resolv.conf
+
+# Clean up any OS_ variables set
+for i in `env | grep OS_ | cut -d'=' -f1`;do unset $i;done
+
+# figure out the port-id from lab credentials
+source ./lab_openrc.sh
+
+port_id=`neutron port-list | grep "$my_mac" | awk '{print $2;}'`
+qrouters=`ip netns list | grep qrouter | cut -f 1 -d ' '`
+aaplist=""
+for qr in $qrouters; do
+    if=`ip netns exec $qr ifconfig | grep qg- | cut -d':' -f1`
+    mac=`ip netns exec $qr ifconfig $if | grep ether | awk '{print $2}'`
+    aaplist="$aaplist mac_address=$mac,ip_address=$cidr"
+done
+
+neutron port-update $port_id  --allowed-address-pairs type=dict list=true $aaplist 

--- a/rocky/setup-avi-heat
+++ b/rocky/setup-avi-heat
@@ -1,0 +1,23 @@
+set -x
+
+# # explicitly set locale to avoid any pip install issues
+export LC_ALL=C
+# clone avi-heat
+cd /root
+git clone $HEAT_REPO
+cd avi-heat
+git checkout $HEAT_BRANCH
+python setup.py sdist
+pip install dist/*tar.gz
+
+sed -i '1 a plugin_dirs = "/usr/local/lib/python2.7/dist-packages/avi/heat"' /etc/heat/heat.conf
+
+pkill -9 heat-engine
+service heat-engine start
+
+
+source /root/admin-openrc.sh
+openstack service create  --name avi --description "Avi LBaaS" avi-lbaas
+openstack endpoint create --region RegionOne avi-lbaas public https://${AVI_IP}/api
+
+

--- a/rocky/wsgi-keystone.conf
+++ b/rocky/wsgi-keystone.conf
@@ -1,0 +1,26 @@
+Listen 5000
+
+<VirtualHost *:5000>
+    WSGIDaemonProcess keystone-public processes=5 threads=1 user=keystone group=keystone display-name=%{GROUP}
+    WSGIProcessGroup keystone-public
+    WSGIScriptAlias / /usr/bin/keystone-wsgi-public
+    WSGIApplicationGroup %{GLOBAL}
+    WSGIPassAuthorization On
+    ErrorLogFormat "%{cu}t %M"
+    ErrorLog /var/log/apache2/keystone.log
+    CustomLog /var/log/apache2/keystone_access.log combined
+
+    <Directory /usr/bin>
+        Require all granted
+    </Directory>
+</VirtualHost>
+
+Alias /identity /usr/local/bin/keystone-wsgi-public
+<Location /identity>
+    SetHandler wsgi-script
+    Options +ExecCGI
+
+    WSGIProcessGroup keystone-public
+    WSGIApplicationGroup %{GLOBAL}
+    WSGIPassAuthorization On
+</Location>

--- a/vm-heat-template/devstack-1804.yaml
+++ b/vm-heat-template/devstack-1804.yaml
@@ -1,0 +1,38 @@
+heat_template_version: 2014-10-16
+description:
+parameters:
+  vm_name:
+    type: string
+  az:
+    type: string
+    default: nova
+  net2:
+    type: string
+  net1:
+    type: string
+    default: avimgmt
+  flavor:
+    type: string
+    default: m1.xlarge
+  image:
+    type: string
+    default: ubuntu-14.04
+
+resources:
+  devstack_vm:
+    type: OS::Nova::Server
+    properties:
+      name: { get_param: vm_name }
+      flavor: { get_param: flavor }
+      image: { get_param: image }
+      networks:
+        - network: { get_param: net1 } 
+        - network: { get_param: net2 }
+      config_drive: True
+      availability_zone: { get_param: az }
+      user_data: { get_file: devstack_vm_init-1804.sh }
+      user_data_format: RAW
+
+outputs:
+  dev_address:
+    value: { get_attr: [devstack_vm, networks, { get_param: net1 }, 0] }

--- a/vm-heat-template/devstack_vm_init-1804.sh
+++ b/vm-heat-template/devstack_vm_init-1804.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+adduser --gecos "" aviuser
+
+# add key
+mkdir -p /home/aviuser/.ssh
+chmod 700 /home/aviuser/.ssh
+cat << EOF > /home/aviuser/.ssh/authorized_keys
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCUqFpC+0FPbFWBEj02X7jEDu4JPReAsr32y/H+s1nPNgx+qfGdYjEcZDTbxpAviMdgL90og7r0jWfQGFLN2wAJe9leRG8NZa2WVNq4Xrx8G/sdXk1TpqVE5PCNT+xd+q9xK3hGpCcGGq46qspTtcZUkhb0MCXbTyPHNiLh3VlKpQv1zC554z9jYKetj8tR6bGuhdBGd9ths3H7Vzi9ZA5w3hzZU83kHJLTW/vD5deq72lehHCmOjFEBILoQGjg3VEjjhS/PfSf9JkCYfJeJhGwM1dkuveDN9ahJ43XAKXOlPLoUB3YvjoXhbfj+ob4NS328A52M38zdsIi+gHsFpuB root@avi-dev
+EOF
+chown -R aviuser:aviuser /home/aviuser/.ssh
+chmod 700 /home/aviuser/.ssh/authorized_keys
+
+# add keys in root too
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+cat << EOF > /root/.ssh/authorized_keys
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCUqFpC+0FPbFWBEj02X7jEDu4JPReAsr32y/H+s1nPNgx+qfGdYjEcZDTbxpAviMdgL90og7r0jWfQGFLN2wAJe9leRG8NZa2WVNq4Xrx8G/sdXk1TpqVE5PCNT+xd+q9xK3hGpCcGGq46qspTtcZUkhb0MCXbTyPHNiLh3VlKpQv1zC554z9jYKetj8tR6bGuhdBGd9ths3H7Vzi9ZA5w3hzZU83kHJLTW/vD5deq72lehHCmOjFEBILoQGjg3VEjjhS/PfSf9JkCYfJeJhGwM1dkuveDN9ahJ43XAKXOlPLoUB3YvjoXhbfj+ob4NS328A52M38zdsIi+gHsFpuB root@avi-dev
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDHTaoO7+AqUSHAk2DRVVGZVc8TYWvBo0rdbAo7DstD3hMqR4A0uA42KFsE2bRSMCz8kEjnG0cvH5FxbEVQGCt0NHzoM0jHk8g5AudRrloRJ/n+bYeWACtsmINi5m9r9CigrUWpQmQR4rTvwhCJPo9azOF0S63v6XNs4Vo+2LK1fr8KxC/dy1fy0cdpXvEva3Wp7AoyBxKagriwHy3Pp6OMroxh57r42H+RkhcYBhEb8uy++GPylXuGO77EWXhlcL1KfXJ0skYnwL9B2OCPnP8Opj0TDWxS6SwtY/WJIR/5eKTFeB5yeFRAwX2Wo9sr8Np86SKA0DUslJENGpa3ivHl root@avi-dev
+EOF
+chown -R root:root /root/.ssh
+chmod 700 /root/.ssh/authorized_keys
+
+
+# enable Password authentication and root login
+# set root password to avi123
+sed -i s/PasswordAuthentication\ no/PasswordAuthentication\ yes/g /etc/ssh/sshd_config
+sed -i s/PermitRootLogin\ without-password/PermitRootLogin\ yes/g /etc/ssh/sshd_config
+sed -i 's/prohibit-password/yes/' /etc/ssh/sshd_config
+service ssh restart
+echo -e 'avi123\navi123' | passwd root
+
+# some bug.. found solution online
+echo "GRUB_DISABLE_OS_PROBER=true" >> /etc/default/grub
+update-grub
+
+# add sudo
+cat << EOF > /etc/sudoers.d/aviuser
+aviuser   ALL=(ALL:ALL) NOPASSWD:ALL
+EOF
+
+
+# Add ens4 for external routing
+cat << EOF >> /etc/systemd/network/10-netplan-ens4.network
+[Match]
+# If you know the MAC address otherwise match on name
+# MacAddress=<>
+Name=ens4
+
+[Network]
+DHCP=ipv4
+LinkLocalAddressing=ipv6
+
+[DHCP]
+UseRoutes=false
+UseMTU=true
+# Use following to add a less preferred default route or set
+# UseRoutes=False to avoid adding any default route from DHCP for this
+# interface. Having two default routes for two interfaces is causing
+# issues with routing.
+# RouteMetric=200
+EOF
+
+ip link set ens4 down
+ip link set ens4 up
+
+# add hostname to /etc/hosts
+echo -n "127.0.0.1 " >> /etc/hosts
+cat /etc/hostname >> /etc/hosts


### PR DESCRIPTION
* Newton support

* Fix routing issue with 1804 Ubuntu VM

On Ubunu18.04, netplan is responsible for bringing up the networks
interfaces, and when it runs DHCP on multiple interfaces, it adds all
the routes for default gateway for each interface. Before this, the
default gateway entry was only added for primary interface. This is
causing routing issue on Ubuntu 1804 VM.

The fix will add explicit entry in network system config to ignore route
from secondary interface DHCP response.

From Rocky release of OpenStack Ubuntu 1804 VM will be used to bring a
AIO OpenStack.

* Rocky install files