### PR TITLE
Fix barbican conf (#38)

### DIFF
--- a/queens/barbican.conf
+++ b/queens/barbican.conf
@@ -119,7 +119,7 @@ max_limit_paging = 100
 [oslo_messaging_rabbit]
 
 # Rabbit and HA configuration:
-amqp_durable_queues = True
+amqp_durable_queues = False
 rabbit_userid=guest
 rabbit_password=guest
 rabbit_ha_queues = True

--- a/rocky/barbican.conf
+++ b/rocky/barbican.conf
@@ -119,7 +119,7 @@ max_limit_paging = 100
 [oslo_messaging_rabbit]
 
 # Rabbit and HA configuration:
-amqp_durable_queues = True
+amqp_durable_queues = False
 rabbit_userid=guest
 rabbit_password=guest
 rabbit_ha_queues = True


### PR DESCRIPTION
barbican-worker is not able to create queue in RabbitMQ because the
durability setting is not matching. Changed the durability setting.

This was causing barbican-worker to run in a loop consuming lot of CPU
and possibly affecting performance of other services in AIO OpenStack
system.